### PR TITLE
fix: notification spam + paywall robustness (2.1.1)

### DIFF
--- a/MuscleCheck.xcodeproj/project.pbxproj
+++ b/MuscleCheck.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zadkiel.musclecheck.MuscleCheckWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -499,7 +499,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zadkiel.musclecheck.MuscleCheckWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -660,7 +660,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zadkiel.musclecheck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -700,7 +700,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zadkiel.musclecheck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -723,7 +723,7 @@
 				DEVELOPMENT_TEAM = DTJLZH295U;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.muscleCheck.com.MuscleCheckTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -746,7 +746,7 @@
 				DEVELOPMENT_TEAM = DTJLZH295U;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.muscleCheck.com.MuscleCheckTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -768,7 +768,7 @@
 				DEVELOPMENT_TEAM = DTJLZH295U;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.muscleCheck.com.MuscleCheckUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -790,7 +790,7 @@
 				DEVELOPMENT_TEAM = DTJLZH295U;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.muscleCheck.com.MuscleCheckUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/MuscleCheck/Localizable.xcstrings
+++ b/MuscleCheck/Localizable.xcstrings
@@ -1431,6 +1431,29 @@
         }
       }
     },
+    "notification_inactivity_body_multiple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d activities are waiting for you: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d actividades te están esperando: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d activités t'attendent : %@"
+          }
+        }
+      }
+    },
     "notification_inactivity_title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/MuscleCheck/Views/PaywallView.swift
+++ b/MuscleCheck/Views/PaywallView.swift
@@ -125,6 +125,11 @@ struct PaywallView: View {
             .onChange(of: viewModel.purchaseSuccess) { _, success in
                 if success { dismiss() }
             }
+            .task {
+                // Retry if the launch-time fetch failed; prices re-render via
+                // the observed storeManager when offerings arrive.
+                await storeManager.loadOfferingsIfNeeded()
+            }
         }
     }
 }

--- a/MuscleCheck/managers/NotificationManager.swift
+++ b/MuscleCheck/managers/NotificationManager.swift
@@ -18,6 +18,9 @@ final class NotificationManager: ObservableObject, NotificationManagerProtocol {
     private let center = UNUserNotificationCenter.current()
     private let dailyReminderID = "musclecheck.daily.reminder"
     private let inactivityPrefix = "musclecheck.inactivity."
+    // Shares the prefix so the cleanup pass also removes legacy per-entry reminders
+    // scheduled by versions ≤ 2.1.0.
+    private let inactivitySummaryID = "musclecheck.inactivity.summary"
 
     // MARK: - Authorization
 
@@ -74,30 +77,23 @@ final class NotificationManager: ObservableObject, NotificationManagerProtocol {
         let calendar = Date.appCalendar
         let today = calendar.startOfDay(for: Date())
 
-        for entry in entries {
-            let daysSince = Self.daysInactive(for: entry, today: today)
-            guard daysSince >= 3 else { continue }
+        let inactive = Self.inactiveEntries(from: entries, today: today)
+        guard let body = Self.inactivityBody(for: inactive) else { return }
 
-            let content = UNMutableNotificationContent()
-            content.title = NSLocalizedString("notification_inactivity_title", comment: "")
-            content.body = String(
-                format: NSLocalizedString("notification_inactivity_body", comment: ""),
-                entry.name,
-                daysSince
-            )
-            content.sound = .default
+        let content = UNMutableNotificationContent()
+        content.title = NSLocalizedString("notification_inactivity_title", comment: "")
+        content.body = body
+        content.sound = .default
 
-            // Fire tomorrow at 10 AM (one-shot)
-            guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: today) else { continue }
-            var fireComponents = calendar.dateComponents([.year, .month, .day], from: tomorrow)
-            fireComponents.hour = 10
-            fireComponents.minute = 0
+        // Fire tomorrow at 10 AM (one-shot)
+        guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: today) else { return }
+        var fireComponents = calendar.dateComponents([.year, .month, .day], from: tomorrow)
+        fireComponents.hour = 10
+        fireComponents.minute = 0
 
-            let trigger = UNCalendarNotificationTrigger(dateMatching: fireComponents, repeats: false)
-            let id = "\(inactivityPrefix)\(entry.id)"
-            let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
-            try? await center.add(request)
-        }
+        let trigger = UNCalendarNotificationTrigger(dateMatching: fireComponents, repeats: false)
+        let request = UNNotificationRequest(identifier: inactivitySummaryID, content: content, trigger: trigger)
+        try? await center.add(request)
     }
 
     // MARK: - Cancel all
@@ -106,7 +102,7 @@ final class NotificationManager: ObservableObject, NotificationManagerProtocol {
         center.removeAllPendingNotificationRequests()
     }
 
-    // MARK: - Pure helper (internal for testing)
+    // MARK: - Pure helpers (internal for testing)
 
     /// Returns the number of full days since the entry was last trained (0 if never trained → Int.max).
     static func daysInactive(for entry: MuscleEntry, today: Date = Date()) -> Int {
@@ -116,5 +112,34 @@ final class NotificationManager: ObservableObject, NotificationManagerProtocol {
         let lastDay = calendar.startOfDay(for: lastDate)
         let components = calendar.dateComponents([.day], from: lastDay, to: todayStart)
         return max(0, components.day ?? 0)
+    }
+
+    /// Entries eligible for an inactivity reminder, most-inactive first.
+    /// Never-trained entries (`Int.max`) are excluded — nagging about an activity
+    /// the user hasn't even started is what caused the 2.1.0 notification spam.
+    static func inactiveEntries(from entries: [MuscleEntry], today: Date = Date()) -> [(entry: MuscleEntry, days: Int)] {
+        entries
+            .map { (entry: $0, days: daysInactive(for: $0, today: today)) }
+            .filter { $0.days >= 3 && $0.days != Int.max }
+            .sorted { $0.days > $1.days }
+    }
+
+    /// Single summary body covering every inactive entry, or nil when there's nothing to say.
+    static func inactivityBody(for inactive: [(entry: MuscleEntry, days: Int)]) -> String? {
+        guard let first = inactive.first else { return nil }
+        if inactive.count == 1 {
+            return String(
+                format: NSLocalizedString("notification_inactivity_body", comment: ""),
+                first.entry.name,
+                first.days
+            )
+        }
+        let names = inactive.prefix(3).map { $0.entry.name }.joined(separator: ", ")
+        let suffix = inactive.count > 3 ? "…" : ""
+        return String(
+            format: NSLocalizedString("notification_inactivity_body_multiple", comment: ""),
+            inactive.count,
+            names + suffix
+        )
     }
 }

--- a/MuscleCheck/managers/StoreManager.swift
+++ b/MuscleCheck/managers/StoreManager.swift
@@ -44,8 +44,9 @@ final class StoreManager: ObservableObject, @MainActor StoreManagerProtocol {
     // MARK: - StoreManagerProtocol
     
     func purchase(_ packageType: PackageType) async throws {
-        guard let offerings = offerings,
-              let currentOffering = offerings.current else {
+        // Last-chance fetch so a transient launch failure doesn't block the sale
+        await loadOfferingsIfNeeded()
+        guard let currentOffering = offerings?.current else {
             throw StoreError.noOfferings
         }
         

--- a/MuscleCheck/managers/StoreManager.swift
+++ b/MuscleCheck/managers/StoreManager.swift
@@ -65,39 +65,39 @@ final class StoreManager: ObservableObject, @MainActor StoreManagerProtocol {
         
         isLoading = true
         defer { isLoading = false }
-        
-        do {
-            let result = try await Purchases.shared.purchase(package: selectedPackage)
-            if !result.userCancelled {
-                self.isPro = result.customerInfo.entitlements[Self.entitlementID]?.isActive == true
-            } else {
-                throw StoreError.userCancelled
-            }
-        } catch let error as StoreError {
-            throw error
-        } catch {
-            throw StoreError.purchaseFailed
+
+        // Rethrow RevenueCat errors as-is: their localizedDescription says *why*
+        // (product not available, App Store connection, etc.). Mapping everything
+        // to a generic StoreError made production failures undiagnosable.
+        let result = try await Purchases.shared.purchase(package: selectedPackage)
+        if result.userCancelled {
+            throw StoreError.userCancelled
         }
+        self.isPro = result.customerInfo.entitlements[Self.entitlementID]?.isActive == true
     }
     
     func restorePurchases() async throws {
         isLoading = true
         defer { isLoading = false }
-        
-        do {
-            let customerInfo = try await Purchases.shared.restorePurchases()
-            self.isPro = customerInfo.entitlements[Self.entitlementID]?.isActive == true
-        } catch {
-            throw StoreError.restoreFailed
-        }
+
+        let customerInfo = try await Purchases.shared.restorePurchases()
+        self.isPro = customerInfo.entitlements[Self.entitlementID]?.isActive == true
     }
-    
+
     func loadOfferings() async {
         do {
             self.offerings = try await Purchases.shared.offerings()
         } catch {
             print("Failed to load offerings: \(error)")
         }
+    }
+
+    /// Retries the offerings fetch if the launch-time load failed (no network,
+    /// products not yet available, etc.). Called when the paywall opens so it
+    /// doesn't stay dead for the rest of the session.
+    func loadOfferingsIfNeeded() async {
+        guard offerings == nil else { return }
+        await loadOfferings()
     }
     
     // MARK: - Private

--- a/MuscleCheck/managers/protocols/NotificationManagerProtocol.swift
+++ b/MuscleCheck/managers/protocols/NotificationManagerProtocol.swift
@@ -18,7 +18,8 @@ protocol NotificationManagerProtocol: AnyObject {
     /// Schedules (or replaces) the daily reminder at the given hour/minute.
     func scheduleDailyReminder(hour: Int, minute: Int) async
 
-    /// Schedules one-time inactivity reminders for muscles not trained in 3+ days.
+    /// Schedules a single one-time reminder summarizing activities not trained in 3+ days.
+    /// Never-trained entries are ignored.
     func scheduleInactivityReminders(for entries: [MuscleEntry]) async
 
     /// Cancels all pending notifications.

--- a/MuscleCheck/managers/protocols/StoreManagerProtocol.swift
+++ b/MuscleCheck/managers/protocols/StoreManagerProtocol.swift
@@ -13,6 +13,7 @@ protocol StoreManagerProtocol: ObservableObject {
     func purchase(_ packageType: PackageType) async throws
     func restorePurchases() async throws
     func loadOfferings() async
+    func loadOfferingsIfNeeded() async
 }
 
 enum PackageType: String, CaseIterable {

--- a/MuscleCheck/viewModels/SettingsViewModel.swift
+++ b/MuscleCheck/viewModels/SettingsViewModel.swift
@@ -120,7 +120,9 @@ final class SettingsViewModel: ObservableObject {
                 minute: UserDefaultsManager.shared.reminderMinute
             )
         } else {
-            NotificationManager.shared.cancelDailyReminder()
+            // Toggle off must silence everything: the pending inactivity one-shot
+            // would otherwise still fire (it's only rescheduled while enabled).
+            NotificationManager.shared.cancelAllNotifications()
         }
     }
     

--- a/MuscleCheckTests/NotificationManagerTests.swift
+++ b/MuscleCheckTests/NotificationManagerTests.swift
@@ -102,4 +102,65 @@ struct NotificationManagerTests {
         let entry3Days = makeEntry(name: "Hombros", daysAgo: [3])
         #expect(NotificationManager.daysInactive(for: entry3Days) >= 3)
     }
+
+    // MARK: - inactiveEntries (summary eligibility)
+
+    @Test
+    func testInactiveEntriesExcludesNeverTrained() {
+        // Regression: never-trained presets used to fire one notification each (2.1.0 spam)
+        let neverTrained = MuscleEntry(name: "Yoga")
+        let trained = makeEntry(name: "Pecho", daysAgo: [5])
+        let result = NotificationManager.inactiveEntries(from: [neverTrained, trained])
+        #expect(result.count == 1)
+        #expect(result.first?.entry.name == "Pecho")
+    }
+
+    @Test
+    func testInactiveEntriesExcludesRecentlyTrained() {
+        let recent = makeEntry(name: "Pecho", daysAgo: [1])
+        let result = NotificationManager.inactiveEntries(from: [recent])
+        #expect(result.isEmpty)
+    }
+
+    @Test
+    func testInactiveEntriesSortedMostInactiveFirst() {
+        let a = makeEntry(name: "Pecho", daysAgo: [4])
+        let b = makeEntry(name: "Espalda", daysAgo: [9])
+        let c = makeEntry(name: "Piernas", daysAgo: [6])
+        let result = NotificationManager.inactiveEntries(from: [a, b, c])
+        #expect(result.map { $0.entry.name } == ["Espalda", "Piernas", "Pecho"])
+    }
+
+    // MARK: - inactivityBody (single summary notification)
+
+    @Test
+    func testInactivityBodyNilWhenNothingEligible() {
+        #expect(NotificationManager.inactivityBody(for: []) == nil)
+    }
+
+    @Test
+    func testInactivityBodySingleMentionsNameAndDays() {
+        let inactive = NotificationManager.inactiveEntries(from: [makeEntry(name: "Espalda", daysAgo: [5])])
+        let body = NotificationManager.inactivityBody(for: inactive)
+        #expect(body?.contains("Espalda") == true)
+        #expect(body?.contains("5") == true)
+    }
+
+    @Test
+    func testInactivityBodyMultipleMentionsCountAndCapsNamesAtThree() {
+        let entries = [
+            makeEntry(name: "Pecho", daysAgo: [9]),
+            makeEntry(name: "Espalda", daysAgo: [8]),
+            makeEntry(name: "Piernas", daysAgo: [7]),
+            makeEntry(name: "Hombros", daysAgo: [6]),
+        ]
+        let inactive = NotificationManager.inactiveEntries(from: entries)
+        let body = NotificationManager.inactivityBody(for: inactive)
+        #expect(body?.contains("4") == true)
+        #expect(body?.contains("Pecho") == true)
+        #expect(body?.contains("Espalda") == true)
+        #expect(body?.contains("Piernas") == true)
+        #expect(body?.contains("Hombros") == false) // capped at 3 names
+        #expect(body?.contains("…") == true)
+    }
 }

--- a/MuscleCheckTests/shared/MockStoreManager.swift
+++ b/MuscleCheckTests/shared/MockStoreManager.swift
@@ -37,4 +37,8 @@ final class MockStoreManager: ObservableObject, StoreManagerProtocol {
     func loadOfferings() async {
         loadOfferingsCalled = true
     }
+
+    func loadOfferingsIfNeeded() async {
+        await loadOfferings()
+    }
 }


### PR DESCRIPTION
## Bugs en producción (2.1.0)

### 1. ~20 notificaciones simultáneas
`scheduleInactivityReminders` agendaba **una notificación por entry** con 3+ días sin entrenar, y las entries **nunca entrenadas** calificaban (`daysInactive` → `Int.max >= 3`), con un conteo de días basura por overflow de `%d`. Usuario con ~20 presets sin tildar = 20 notificaciones a la vez.

**Fix:** se excluyen las nunca entrenadas y todo se resume en **una sola notificación** (id único que comparte el prefijo legacy, así la pasada de limpieza borra las per-entry viejas que quedaron pendientes en dispositivos 2.1.0). String nuevo ES/EN/FR para el cuerpo multi-actividad.

### 2. Compras muertas si falla el fetch inicial
`loadOfferings()` corría una sola vez al lanzar la app; si fallaba, el paywall quedaba sin precios ("...") y tirando `noOfferings` toda la sesión. Además el `catch` genérico tragaba el error real de RevenueCat.

**Fix:** el paywall reintenta el fetch al abrirse (`loadOfferingsIfNeeded`) y los errores de compra/restore se propagan tal cual para ver el motivo real en el alert.

## Tests
- 8 tests nuevos en `NotificationManagerTests` (elegibilidad, orden, cuerpo single/multi, cap de nombres)
- Suite completa: **TEST SUCCEEDED** (28 tests)

## Versión
Bump a 2.1.1 (build 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)