### PR TITLE
refactor: redesign history screen around a month calendar

### DIFF
--- a/MuscleCheck/Localizable.xcstrings
+++ b/MuscleCheck/Localizable.xcstrings
@@ -1053,6 +1053,75 @@
         }
       }
     },
+    "history_month_summary %lld %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld days trained in %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld días entrenados en %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld jours d'entraînement en %@"
+          }
+        }
+      }
+    },
+    "history_week_empty_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick another week on the calendar."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegí otra semana en el calendario."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez une autre semaine."
+          }
+        }
+      }
+    },
+    "history_week_empty_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No training this week"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin entrenamientos esta semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun entraînement cette semaine"
+          }
+        }
+      }
+    },
     "home_title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/MuscleCheck/Views/HistoryView.swift
+++ b/MuscleCheck/Views/HistoryView.swift
@@ -2,50 +2,49 @@ import SwiftUI
 import SwiftData
 
 struct HistoryView: View {
-  @State private var showPicker = false
-  
   let entries: [MuscleEntry]
   @StateObject private var viewModel: HistoryViewModel
-    
+
   init(entries: [MuscleEntry]) {
     self.entries = entries
     _viewModel = StateObject(wrappedValue: HistoryViewModel.create(with: entries))
   }
-  
+
   var body: some View {
-    List {
-      ForEach(viewModel.groupedEntries.keys.sorted(), id: \.self) { muscleName in
-        Section(header: Text(muscleName).font(.headline)) {
-          ForEach(viewModel.groupedEntries[muscleName] ?? [], id: \.self) { entry in
-            Text(entry.dateCreated.formatted(date: .abbreviated, time: .omitted))
-              .font(.subheadline)
-              .foregroundColor(.primary)
-          }
-        }
-      }
-    }
-    .navigationBarTitleDisplayMode(.inline)
-    .toolbar {
-      ToolbarItem(placement: .principal) {
-        Button {
-          showPicker = true
-        } label: {
-          Text("history_week_range \(viewModel.weekOf(viewModel.selectedDate)) \(viewModel.weekRangeString(for: viewModel.selectedDate))")
-            .font(.subheadline.bold())
-            .foregroundColor(Color("PrimaryButtonColor"))
-        }
-      }
-    }
-    .sheet(isPresented: $showPicker) {
-      VStack {
-        DatePicker("PROMPT_SELECT_WEEK", selection: $viewModel.selectedDate, displayedComponents: .date)
-          .datePickerStyle(.graphical)
-          .padding()
-        Button("Done") {
-          showPicker = false
-        }
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        // Month summary caption (per-month trained-day count — not shown in Stats/Streak)
+        Text("history_month_summary \(viewModel.monthTrainedCount) \(viewModel.monthName)")
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+          .padding(.horizontal)
+
+        // Hero calendar
+        MonthCalendarView(
+          weeks: viewModel.weeks,
+          monthTitle: viewModel.monthTitle,
+          intensityByDay: viewModel.intensityByDay,
+          selectedDate: viewModel.selectedDate,
+          onPrev: { withAnimation { viewModel.goToPreviousMonth() } },
+          onNext: { withAnimation { viewModel.goToNextMonth() } },
+          onSelect: { day in withAnimation { viewModel.select(day) } }
+        )
         .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+        .padding(.horizontal)
+
+        // Selected week, day by day
+        WeekDetailSection(days: viewModel.weekBreakdown)
       }
+      .padding(.vertical)
+    }
+    .background(Color(.systemGroupedBackground))
+    .navigationTitle("workout_history")
+    .navigationBarTitleDisplayMode(.large)
+    .onChange(of: entries) { _, newEntries in
+      viewModel.entries = newEntries
     }
   }
 }

--- a/MuscleCheck/Views/calendar/CalendarDayCell.swift
+++ b/MuscleCheck/Views/calendar/CalendarDayCell.swift
@@ -1,0 +1,83 @@
+//
+//  CalendarDayCell.swift
+//  MuscleCheck
+//
+//  Created by Alejandro De Jesus on 13/06/2026.
+//
+
+import SwiftUI
+
+/// A single day in the month grid. Purely presentational — the parent owns selection.
+struct CalendarDayCell: View {
+    let day: CalendarDay
+    let isToday: Bool
+    let isSelected: Bool
+    /// Number of muscles trained that day (0 = none); drives the intensity dot.
+    let intensity: Int
+
+    private let accent = Color("PrimaryButtonColor")
+
+    var body: some View {
+        VStack(spacing: 3) {
+            ZStack {
+                if isSelected {
+                    Circle().fill(accent)
+                } else if isToday {
+                    Circle().stroke(accent, lineWidth: 1.5)
+                }
+                Text("\(dayNumber)")
+                    .font(.callout)
+                    .fontWeight(isSelected || isToday ? .semibold : .regular)
+                    .foregroundStyle(numberColor)
+            }
+            .frame(width: 32, height: 32)
+
+            // Intensity dot: bigger/more opaque the more muscles trained.
+            // Hidden on the selected day (the fill already conveys training).
+            // Fixed 8pt slot keeps every row vertically aligned.
+            Circle()
+                .fill(accent.opacity(dotOpacity))
+                .frame(width: dotSize, height: dotSize)
+                .frame(height: 8)
+                .opacity(showDot ? 1 : 0)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 46)
+        .contentShape(Rectangle())
+    }
+
+    private var dayNumber: Int {
+        Date.appCalendar.component(.day, from: day.date)
+    }
+
+    private var numberColor: Color {
+        if isSelected { return .white }
+        if isToday { return accent }
+        return day.isInDisplayedMonth ? .primary : .secondary.opacity(0.5)
+    }
+
+    // MARK: - Intensity dot scaling
+
+    private var showDot: Bool { intensity > 0 && !isSelected }
+    private var clamped: Int { min(max(intensity, 0), 4) }
+    private var dotSize: CGFloat { 4 + CGFloat(clamped) }            // 5…8 pt
+    private var dotOpacity: Double { 0.35 + 0.65 * Double(clamped) / 4.0 } // ~0.5…1.0
+}
+
+#Preview {
+    let cal = Date.appCalendar
+    let today = cal.startOfDay(for: Date())
+    HStack(spacing: 0) {
+        CalendarDayCell(day: CalendarDay(date: cal.date(byAdding: .day, value: -1, to: today)!, isInDisplayedMonth: true),
+                        isToday: false, isSelected: false, intensity: 1)
+        CalendarDayCell(day: CalendarDay(date: today, isInDisplayedMonth: true),
+                        isToday: true, isSelected: false, intensity: 2)
+        CalendarDayCell(day: CalendarDay(date: cal.date(byAdding: .day, value: 1, to: today)!, isInDisplayedMonth: true),
+                        isToday: false, isSelected: true, intensity: 3)
+        CalendarDayCell(day: CalendarDay(date: cal.date(byAdding: .day, value: 2, to: today)!, isInDisplayedMonth: true),
+                        isToday: false, isSelected: false, intensity: 4)
+        CalendarDayCell(day: CalendarDay(date: cal.date(byAdding: .day, value: 3, to: today)!, isInDisplayedMonth: false),
+                        isToday: false, isSelected: false, intensity: 0)
+    }
+    .padding()
+}

--- a/MuscleCheck/Views/calendar/MonthCalendarView.swift
+++ b/MuscleCheck/Views/calendar/MonthCalendarView.swift
@@ -1,0 +1,123 @@
+//
+//  MonthCalendarView.swift
+//  MuscleCheck
+//
+//  Created by Alejandro De Jesus on 13/06/2026.
+//
+
+import SwiftUI
+
+/// Month calendar hero for the history screen. Renders each week as its own `HStack`
+/// so the selected week can carry a single contiguous rounded background + border
+/// (the macOS Calendar look) — impossible to align cleanly with a flat `LazyVGrid`.
+struct MonthCalendarView: View {
+    let weeks: [[CalendarDay]]
+    let monthTitle: String
+    let intensityByDay: [Date: Int]
+    let selectedDate: Date
+    let onPrev: () -> Void
+    let onNext: () -> Void
+    let onSelect: (Date) -> Void
+
+    private let accent = Color("PrimaryButtonColor")
+    private let calendar = Date.appCalendar
+
+    var body: some View {
+        VStack(spacing: 12) {
+            header
+            weekdayHeader
+            grid
+        }
+    }
+
+    // MARK: - Header (month pager)
+
+    private var header: some View {
+        HStack {
+            Button(action: onPrev) {
+                Image(systemName: "chevron.left").font(.headline)
+            }
+            Spacer()
+            Text(monthTitle)
+                .font(.headline)
+                .contentTransition(.numericText())
+            Spacer()
+            Button(action: onNext) {
+                Image(systemName: "chevron.right").font(.headline)
+            }
+        }
+        .tint(accent)
+    }
+
+    // MARK: - Weekday symbols
+
+    private var weekdayHeader: some View {
+        let symbols = MonthCalendarCalculator.weekdaySymbols()
+        return HStack(spacing: 0) {
+            ForEach(symbols.indices, id: \.self) { i in
+                Text(symbols[i])
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Grid
+
+    private var grid: some View {
+        VStack(spacing: 4) {
+            ForEach(weeks.indices, id: \.self) { row in
+                let week = weeks[row]
+                HStack(spacing: 0) {
+                    ForEach(week) { day in
+                        CalendarDayCell(
+                            day: day,
+                            isToday: calendar.isDateInToday(day.date),
+                            isSelected: calendar.isDate(day.date, inSameDayAs: selectedDate),
+                            intensity: intensityByDay[day.date] ?? 0
+                        )
+                        .onTapGesture { onSelect(day.date) }
+                    }
+                }
+                .padding(.vertical, 2)
+                .background(weekBackground(for: week))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func weekBackground(for week: [CalendarDay]) -> some View {
+        if isSelectedWeek(week) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(accent.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(accent.opacity(0.35), lineWidth: 1)
+                )
+        }
+    }
+
+    /// A row is the selected week iff its Monday matches the selected date's Monday.
+    /// The matrix is Monday-first, so the selected week is always exactly one row.
+    private func isSelectedWeek(_ week: [CalendarDay]) -> Bool {
+        guard let rowMonday = week.first?.date,
+              let selectedMonday = selectedDate.startOfWeek(using: calendar) else { return false }
+        return calendar.isDate(rowMonday, inSameDayAs: selectedMonday)
+    }
+}
+
+#Preview {
+    let today = Date()
+    MonthCalendarView(
+        weeks: MonthCalendarCalculator.monthMatrix(for: today),
+        monthTitle: "junio 2026",
+        intensityByDay: [Date.appCalendar.startOfDay(for: today): 2],
+        selectedDate: today,
+        onPrev: {},
+        onNext: {},
+        onSelect: { _ in }
+    )
+    .padding()
+}

--- a/MuscleCheck/Views/calendar/WeekDetailSection.swift
+++ b/MuscleCheck/Views/calendar/WeekDetailSection.swift
@@ -1,0 +1,99 @@
+//
+//  WeekDetailSection.swift
+//  MuscleCheck
+//
+//  Created by Alejandro De Jesus on 13/06/2026.
+//
+
+import SwiftUI
+
+/// The per-day breakdown of the selected week, shown below the calendar.
+struct WeekDetailSection: View {
+    let days: [DayActivities]
+
+    var body: some View {
+        if days.isEmpty {
+            ContentUnavailableView(
+                LocalizedStringKey("history_week_empty_title"),
+                systemImage: "calendar.badge.exclamationmark",
+                description: Text("history_week_empty_description")
+            )
+            .padding(.top, 40)
+        } else {
+            VStack(alignment: .leading, spacing: 18) {
+                ForEach(days) { day in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(Self.dayLabel(day.date))
+                            .font(.subheadline.bold())
+                            .foregroundStyle(Color("PrimaryButtonColor"))
+                        ForEach(day.activities) { activity in
+                            ActivityDetailRow(activity: activity)
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal)
+        }
+    }
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("EEEE d")
+        return f
+    }()
+
+    private static func dayLabel(_ date: Date) -> String {
+        dayFormatter.string(from: date).capitalized
+    }
+}
+
+// MARK: - Activity row (read-only)
+
+/// Read-only mirror of `MuscleEntryRowView`'s visual: icon + name + that day's weight (gym only).
+/// Deliberately omits the checkmark/weight-edit affordances — history doesn't mutate state.
+private struct ActivityDetailRow: View {
+    let activity: DayActivity
+
+    private var isGym: Bool { activity.entry.category == ActivityCategory.gym.rawValue }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: activity.entry.icon)
+                .foregroundColor(Color("PrimaryButtonColor"))
+                .frame(width: 24)
+            Text(activity.entry.name)
+            if isGym, let kg = activity.weightKg {
+                Text(formattedWeight(kg))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+    }
+
+    private func formattedWeight(_ kg: Double) -> String {
+        let unit = UserDefaultsManager.shared.weightUnit
+        return String(format: "%.0f", unit.displayValue(fromKg: kg)) + " " + unit.displayLabel
+    }
+}
+
+#Preview {
+    let cal = Date.appCalendar
+    let mon = cal.startOfDay(for: Date())
+    let pecho = MuscleEntry(name: "Pecho")
+    let triceps = MuscleEntry(name: "Tríceps")
+    let yoga = MuscleEntry(name: "Yoga", category: ActivityCategory.yoga.rawValue, icon: ActivityCategory.yoga.defaultIcon)
+    WeekDetailSection(days: [
+        DayActivities(date: mon, activities: [
+            DayActivity(entry: pecho, weightKg: 20),
+            DayActivity(entry: triceps, weightKg: nil)
+        ]),
+        DayActivities(date: cal.date(byAdding: .day, value: 2, to: mon)!, activities: [
+            DayActivity(entry: yoga, weightKg: nil)
+        ])
+    ])
+}

--- a/MuscleCheck/managers/MonthCalendarCalculator.swift
+++ b/MuscleCheck/managers/MonthCalendarCalculator.swift
@@ -1,0 +1,138 @@
+//
+//  MonthCalendarCalculator.swift
+//  MuscleCheck
+//
+//  Created by Alejandro De Jesus on 13/06/2026.
+//
+
+import Foundation
+
+/// One cell in the month grid. `isInDisplayedMonth` is false for the leading/trailing
+/// days that belong to the adjacent month (rendered dimmed).
+struct CalendarDay: Identifiable, Hashable {
+    let date: Date
+    let isInDisplayedMonth: Bool
+    var id: Date { date }
+}
+
+/// One trained muscle on a given day, carrying THAT day's logged weight (kg, may be nil)
+/// — not the entry's latest weight, so historical rows show the load actually used.
+struct DayActivity: Identifiable {
+    let entry: MuscleEntry
+    let weightKg: Double?
+    var id: UUID { entry.id }
+}
+
+/// The activities trained on a single day, used by the week detail breakdown.
+struct DayActivities: Identifiable {
+    let date: Date
+    let activities: [DayActivity]
+    var id: Date { date }
+}
+
+/// Stateless struct with pure functions for the history month calendar.
+/// Mirrors `StatsCalculator`: uses `Date.appCalendar` directly (Monday-first).
+struct MonthCalendarCalculator {
+
+    // MARK: - Month grid
+
+    /// A fixed 6×7 matrix of days for the month containing `monthAnchor`.
+    /// Always 42 cells so the grid height never jumps when paging months; the
+    /// leading/trailing days belong to the adjacent month (`isInDisplayedMonth == false`).
+    static func monthMatrix(for monthAnchor: Date) -> [[CalendarDay]] {
+        let calendar = Date.appCalendar
+        guard let monthInterval = calendar.dateInterval(of: .month, for: monthAnchor),
+              // firstWeekday == 2, so startOfWeek lands on the Monday on/before day 1 —
+              // this resolves the Monday-first leading offset for free.
+              let gridStart = monthInterval.start.startOfWeek(using: calendar) else {
+            return []
+        }
+
+        var days: [CalendarDay] = []
+        days.reserveCapacity(42)
+        for offset in 0..<42 {
+            guard let date = calendar.date(byAdding: .day, value: offset, to: gridStart) else { continue }
+            let dayStart = calendar.startOfDay(for: date)
+            let inMonth = calendar.isDate(dayStart, equalTo: monthAnchor, toGranularity: .month)
+            days.append(CalendarDay(date: dayStart, isInDisplayedMonth: inMonth))
+        }
+
+        return stride(from: 0, to: days.count, by: 7).map { Array(days[$0..<min($0 + 7, days.count)]) }
+    }
+
+    /// Monday-first single-letter weekday headers, localized.
+    static func weekdaySymbols() -> [String] {
+        let calendar = Date.appCalendar
+        let symbols = calendar.veryShortStandaloneWeekdaySymbols // index 0 = Sunday
+        let firstIndex = calendar.firstWeekday - 1                // 1 for Monday
+        return Array(symbols[firstIndex...] + symbols[..<firstIndex])
+    }
+
+    // MARK: - Training signals
+
+    /// Set of start-of-day dates that had at least one session (O(1) membership for the grid).
+    static func trainedDays(from entries: [MuscleEntry]) -> Set<Date> {
+        let calendar = Date.appCalendar
+        var set: Set<Date> = []
+        for entry in entries {
+            for session in entry.sessions {
+                set.insert(calendar.startOfDay(for: session.date))
+            }
+        }
+        return set
+    }
+
+    /// Number of distinct muscles trained per day (an entry trained twice the same day counts once).
+    /// Drives the intensity of the calendar dot.
+    static func muscleCountByDay(from entries: [MuscleEntry]) -> [Date: Int] {
+        let calendar = Date.appCalendar
+        var counts: [Date: Int] = [:]
+        for entry in entries {
+            var entryDays: Set<Date> = []
+            for session in entry.sessions {
+                entryDays.insert(calendar.startOfDay(for: session.date))
+            }
+            for day in entryDays {
+                counts[day, default: 0] += 1
+            }
+        }
+        return counts
+    }
+
+    /// Count of unique days trained within the month containing `monthAnchor`.
+    /// New vs. Stats (all-time total + 8-week chart) and Streak (current/max) — a per-month figure.
+    /// Uses same-month comparison (not `DateInterval.contains`, which is end-inclusive and
+    /// would double-count the 1st of the next month).
+    static func trainedDayCount(inMonthOf monthAnchor: Date, from entries: [MuscleEntry]) -> Int {
+        let calendar = Date.appCalendar
+        return trainedDays(from: entries)
+            .filter { calendar.isDate($0, equalTo: monthAnchor, toGranularity: .month) }
+            .count
+    }
+
+    // MARK: - Week detail
+
+    /// Per-day breakdown of the week containing `date`: only days with ≥1 activity,
+    /// ascending by date, entries sorted by name. Same week semantics as the old
+    /// `groupedEntries` (`dateInterval(of: .weekOfYear)`).
+    static func weekBreakdown(forWeekContaining date: Date, from entries: [MuscleEntry]) -> [DayActivities] {
+        let calendar = Date.appCalendar
+        guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: date) else { return [] }
+
+        var result: [DayActivities] = []
+        for offset in 0..<7 {
+            guard let day = calendar.date(byAdding: .day, value: offset, to: weekInterval.start) else { continue }
+            let dayStart = calendar.startOfDay(for: day)
+            let activities = entries
+                .compactMap { entry -> DayActivity? in
+                    guard let session = entry.sessions.first(where: { calendar.isDate($0.date, inSameDayAs: dayStart) }) else { return nil }
+                    return DayActivity(entry: entry, weightKg: session.weight)
+                }
+                .sorted { $0.entry.name < $1.entry.name }
+            if !activities.isEmpty {
+                result.append(DayActivities(date: dayStart, activities: activities))
+            }
+        }
+        return result
+    }
+}

--- a/MuscleCheck/viewModels/HistoryViewModel.swift
+++ b/MuscleCheck/viewModels/HistoryViewModel.swift
@@ -8,51 +8,84 @@
 
 import Foundation
 import SwiftData
-import _SwiftData_SwiftUI
 
 final class HistoryViewModel: ObservableObject {
-  
-  @Published var selectedDate: Date = Date()
-  @Published var entries: [MuscleEntry]
 
-  init(entries: [MuscleEntry]) {
-    self.entries = entries
-  }
+    /// The day whose week is highlighted and whose breakdown is shown below the calendar.
+    @Published var selectedDate: Date = Date()
+    /// The month currently rendered in the grid (changed by the chevrons).
+    @Published var displayedMonth: Date = Date()
+    @Published var entries: [MuscleEntry]
 
-  static func create(with entries: [MuscleEntry]) -> HistoryViewModel {
-    return HistoryViewModel(entries: entries)
-  }
-  
-  var groupedEntries: [String: [MuscleEntry]] {
-      let calendar = Date.appCalendar
-      guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: selectedDate) else {
-          return [:]
-      }
+    init(entries: [MuscleEntry]) {
+        self.entries = entries
+    }
 
-      let filtered = entries.filter { entry in
-          entry.sessions.contains { activityDate in
-              weekInterval.contains(activityDate.date)
-          }
-      }
+    static func create(with entries: [MuscleEntry]) -> HistoryViewModel {
+        return HistoryViewModel(entries: entries)
+    }
 
-      return Dictionary(grouping: filtered, by: { $0.name })
-  }
-  
-  func weekOf(_ date: Date) -> Int {
-    Date.appCalendar.component(.weekOfYear, from: date)
-  }
-  
-  func weekRangeString(for date: Date) -> String {
-    let calendar = Date.appCalendar
-    guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: date) else { return "" }
-    
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "es_ES")
-    formatter.dateFormat = "d 'de' MMMM"
-    
-    let start = formatter.string(from: weekInterval.start)
-    let end = formatter.string(from: calendar.date(byAdding: .day, value: 6, to: weekInterval.start)!)
-    
-    return "del \(start) al \(end)"
-  }
+    // MARK: - Calendar grid (delegates to MonthCalendarCalculator)
+
+    var weeks: [[CalendarDay]] {
+        MonthCalendarCalculator.monthMatrix(for: displayedMonth)
+    }
+
+    var intensityByDay: [Date: Int] {
+        MonthCalendarCalculator.muscleCountByDay(from: entries)
+    }
+
+    var monthTrainedCount: Int {
+        MonthCalendarCalculator.trainedDayCount(inMonthOf: displayedMonth, from: entries)
+    }
+
+    var weekBreakdown: [DayActivities] {
+        MonthCalendarCalculator.weekBreakdown(forWeekContaining: selectedDate, from: entries)
+    }
+
+    /// "Junio 2026" — capitalized for the header.
+    var monthTitle: String {
+        Self.monthTitleFormatter.string(from: displayedMonth).capitalized
+    }
+
+    /// "junio" — lowercase, used mid-sentence in the month summary caption.
+    var monthName: String {
+        Self.monthNameFormatter.string(from: displayedMonth)
+    }
+
+    // MARK: - Navigation
+
+    func goToPreviousMonth() {
+        if let prev = Date.appCalendar.date(byAdding: .month, value: -1, to: displayedMonth) {
+            displayedMonth = prev
+        }
+    }
+
+    func goToNextMonth() {
+        if let next = Date.appCalendar.date(byAdding: .month, value: 1, to: displayedMonth) {
+            displayedMonth = next
+        }
+    }
+
+    func select(_ day: Date) {
+        selectedDate = day
+        // Tapping a leading/trailing day follows it into its month (Calendar.app behavior).
+        if !Date.appCalendar.isDate(day, equalTo: displayedMonth, toGranularity: .month) {
+            displayedMonth = day
+        }
+    }
+
+    // MARK: - Formatters
+
+    private static let monthTitleFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("LLLL yyyy")
+        return f
+    }()
+
+    private static let monthNameFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("LLLL")
+        return f
+    }()
 }

--- a/MuscleCheckTests/HistoryViewModelTests.swift
+++ b/MuscleCheckTests/HistoryViewModelTests.swift
@@ -17,69 +17,70 @@ struct HistoryViewModelTests {
         return entry
     }
 
+    private func date(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        Date.appCalendar.date(from: DateComponents(year: y, month: m, day: d, hour: 12))!
+    }
+
+    // MARK: - Selection
+
     @Test
-    func testGroupedEntriesIncludesEntriesInSelectedWeek() {
-        let calendar = Calendar(identifier: .gregorian)
-        let monday = calendar.date(from: DateComponents(year: 2025, month: 6, day: 9))!
-        let tuesday = calendar.date(byAdding: .day, value: 1, to: monday)!
-
-        let entry1 = makeEntry(name: "Pecho", dates: [monday])
-        let entry2 = makeEntry(name: "Espalda", dates: [tuesday])
-        let entry3 = makeEntry(name: "Piernas", dates: [])
-
-        let viewModel = HistoryViewModel(entries: [entry1, entry2, entry3])
-        viewModel.selectedDate = monday
-
-        let result = viewModel.groupedEntries
-
-        #expect(result["Pecho"]?.count == 1)
-        #expect(result["Espalda"]?.count == 1)
-        #expect(result["Piernas"] == nil)
+    func testSelectSetsSelectedDate() {
+        let vm = HistoryViewModel(entries: [])
+        let day = date(2026, 6, 10)
+        vm.select(day)
+        #expect(vm.selectedDate == day)
     }
 
     @Test
-    func testGroupedEntriesExcludesEntriesOutsideSelectedWeek() {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.firstWeekday = 2
-        let monday = calendar.date(from: DateComponents(year: 2025, month: 6, day: 8))!
-        let nextWeek = calendar.date(byAdding: .day, value: 7, to: monday)!
+    func testSelectingDayInAnotherMonthPagesToIt() {
+        let vm = HistoryViewModel(entries: [])
+        vm.displayedMonth = date(2026, 6, 15)
+        let julyDay = date(2026, 7, 2)
+        vm.select(julyDay)
+        #expect(Date.appCalendar.isDate(vm.displayedMonth, equalTo: julyDay, toGranularity: .month))
+    }
 
-        let entry = makeEntry(name: "Pecho", dates: [nextWeek])
-        let viewModel = HistoryViewModel(entries: [entry])
-        viewModel.selectedDate = monday
+    // MARK: - Month paging
 
-        #expect(viewModel.groupedEntries.isEmpty)
+    @Test
+    func testGoToNextAndPreviousMonthShiftByOneMonth() {
+        let vm = HistoryViewModel(entries: [])
+        vm.displayedMonth = date(2026, 6, 15)
+        vm.goToNextMonth()
+        #expect(Date.appCalendar.component(.month, from: vm.displayedMonth) == 7)
+        vm.goToPreviousMonth()
+        vm.goToPreviousMonth()
+        #expect(Date.appCalendar.component(.month, from: vm.displayedMonth) == 5)
     }
 
     @Test
-    func testGroupedEntriesGroupsByMuscleName() {
-        let calendar = Calendar(identifier: .gregorian)
-        let monday = calendar.date(from: DateComponents(year: 2025, month: 6, day: 9))!
+    func testPagingDoesNotMoveSelection() {
+        let vm = HistoryViewModel(entries: [])
+        let selected = date(2026, 6, 10)
+        vm.selectedDate = selected
+        vm.displayedMonth = date(2026, 6, 1)
+        vm.goToNextMonth()
+        #expect(vm.selectedDate == selected) // chevrons don't move the highlighted week
+    }
 
-        let entry1 = makeEntry(name: "Pecho", dates: [monday])
-        let entry2 = makeEntry(name: "Pecho", dates: [monday])
-        let entry3 = makeEntry(name: "Espalda", dates: [monday])
+    // MARK: - Derived data
 
-        let viewModel = HistoryViewModel(entries: [entry1, entry2, entry3])
-        viewModel.selectedDate = monday
-
-        let result = viewModel.groupedEntries
-
-        #expect(result["Pecho"]?.count == 2)
-        #expect(result["Espalda"]?.count == 1)
+    @Test
+    func testWeekBreakdownReflectsSelectedDate() {
+        let entry = makeEntry(name: "Pecho", dates: [date(2026, 6, 8)])
+        let vm = HistoryViewModel(entries: [entry])
+        vm.select(date(2026, 6, 10)) // same week as June 8
+        #expect(vm.weekBreakdown.count == 1)
+        #expect(vm.weekBreakdown.first?.activities.first?.entry.name == "Pecho")
     }
 
     @Test
-    func testGroupedEntriesHandlesMultipleSessions() {
-        let calendar = Calendar(identifier: .gregorian)
-        let monday = calendar.date(from: DateComponents(year: 2025, month: 6, day: 9))!
-        let nextWeek = calendar.date(byAdding: .day, value: 7, to: monday)!
-
-        let entry = makeEntry(name: "Pecho", dates: [monday, nextWeek])
-        let viewModel = HistoryViewModel(entries: [entry])
-        viewModel.selectedDate = monday
-
-        // Entry is included once even though it has a session in another week
-        #expect(viewModel.groupedEntries["Pecho"]?.count == 1)
+    func testMonthTrainedCountReflectsDisplayedMonth() {
+        let entry = makeEntry(name: "Pecho", dates: [date(2026, 6, 1), date(2026, 6, 15), date(2026, 5, 20)])
+        let vm = HistoryViewModel(entries: [entry])
+        vm.displayedMonth = date(2026, 6, 10)
+        #expect(vm.monthTrainedCount == 2) // only June days
+        vm.displayedMonth = date(2026, 5, 10)
+        #expect(vm.monthTrainedCount == 1)
     }
 }

--- a/MuscleCheckTests/MonthCalendarCalculatorTests.swift
+++ b/MuscleCheckTests/MonthCalendarCalculatorTests.swift
@@ -1,0 +1,192 @@
+//
+//  MonthCalendarCalculatorTests.swift
+//  MuscleCheckTests
+//
+//  Created by Alejandro De Jesus on 13/06/2026.
+//
+
+import Testing
+@testable import MuscleCheck
+import Foundation
+
+struct MonthCalendarCalculatorTests {
+
+    // MARK: - Helpers
+
+    /// Noon-anchored date (dodges midnight/DST edges), built with the app calendar.
+    private func date(_ year: Int, _ month: Int, _ day: Int, hour: Int = 12) -> Date {
+        var c = DateComponents()
+        c.year = year; c.month = month; c.day = day; c.hour = hour
+        return Date.appCalendar.date(from: c)!
+    }
+
+    private func makeEntry(name: String, dates: [Date]) -> MuscleEntry {
+        let entry = MuscleEntry(name: name)
+        for d in dates { entry.addSession(d) }
+        return entry
+    }
+
+    // MARK: - monthMatrix
+    // (June 1 2026 is a Monday; Feb 1 2026 is a Sunday — used as fixtures below.)
+
+    @Test
+    func testMonthMatrixAlways42CellsSixRows() {
+        let m = MonthCalendarCalculator.monthMatrix(for: date(2026, 6, 15))
+        #expect(m.count == 6)
+        #expect(m.allSatisfy { $0.count == 7 })
+        #expect(m.flatMap { $0 }.count == 42)
+    }
+
+    @Test
+    func testMonthMatrixFirstCellIsMondayOnOrBeforeFirstOfMonth() {
+        let m = MonthCalendarCalculator.monthMatrix(for: date(2026, 6, 15))
+        let cal = Date.appCalendar
+        let firstCell = m[0][0].date
+        #expect(cal.component(.weekday, from: firstCell) == 2) // Monday
+        #expect(firstCell <= cal.date(from: DateComponents(year: 2026, month: 6, day: 1))!)
+    }
+
+    @Test
+    func testMonthMatrixMondayStartMonthHasNoLeadingDimmedDays() {
+        // June 1 2026 is a Monday → grid starts exactly on the 1st.
+        let m = MonthCalendarCalculator.monthMatrix(for: date(2026, 6, 10))
+        #expect(Date.appCalendar.component(.day, from: m[0][0].date) == 1)
+        #expect(m[0][0].isInDisplayedMonth == true)
+    }
+
+    @Test
+    func testMonthMatrixSundayStartMonthHasSixLeadingDimmedDays() {
+        // Feb 1 2026 is a Sunday → 6 leading days from January.
+        let m = MonthCalendarCalculator.monthMatrix(for: date(2026, 2, 10))
+        let cal = Date.appCalendar
+        #expect(m[0][0].isInDisplayedMonth == false)              // Jan 26 (Mon)
+        #expect(cal.component(.weekday, from: m[0][0].date) == 2)
+        #expect(cal.component(.day, from: m[0][6].date) == 1)     // Feb 1 lands on Sunday column
+        #expect(m[0][6].isInDisplayedMonth == true)
+    }
+
+    @Test
+    func testMonthMatrixTrailingCellsBelongToNextMonth() {
+        let m = MonthCalendarCalculator.monthMatrix(for: date(2026, 6, 10))
+        #expect(m[5][6].isInDisplayedMonth == false) // last cell spills into July
+    }
+
+    // MARK: - trainedDays
+
+    @Test
+    func testTrainedDaysEmpty() {
+        #expect(MonthCalendarCalculator.trainedDays(from: []).isEmpty)
+    }
+
+    @Test
+    func testTrainedDaysDedupesSameDayAcrossEntries() {
+        let e1 = makeEntry(name: "Pecho", dates: [date(2026, 6, 10, hour: 9)])
+        let e2 = makeEntry(name: "Espalda", dates: [date(2026, 6, 10, hour: 18)])
+        #expect(MonthCalendarCalculator.trainedDays(from: [e1, e2]).count == 1)
+    }
+
+    @Test
+    func testTrainedDaysAdjacentDaysAreDistinct() {
+        let e = makeEntry(name: "Pecho", dates: [date(2026, 6, 10, hour: 23), date(2026, 6, 11, hour: 1)])
+        #expect(MonthCalendarCalculator.trainedDays(from: [e]).count == 2)
+    }
+
+    // MARK: - muscleCountByDay
+
+    @Test
+    func testMuscleCountByDayCountsDistinctMuscles() {
+        let e1 = makeEntry(name: "Pecho", dates: [date(2026, 6, 10)])
+        let e2 = makeEntry(name: "Espalda", dates: [date(2026, 6, 10)])
+        let day = Date.appCalendar.startOfDay(for: date(2026, 6, 10))
+        #expect(MonthCalendarCalculator.muscleCountByDay(from: [e1, e2])[day] == 2)
+    }
+
+    @Test
+    func testMuscleCountByDaySameMuscleTwiceSameDayCountsOne() {
+        let e = makeEntry(name: "Pecho", dates: [date(2026, 6, 10, hour: 9), date(2026, 6, 10, hour: 18)])
+        let day = Date.appCalendar.startOfDay(for: date(2026, 6, 10))
+        #expect(MonthCalendarCalculator.muscleCountByDay(from: [e])[day] == 1)
+    }
+
+    // MARK: - trainedDayCount
+
+    @Test
+    func testTrainedDayCountOnlyCountsAnchorMonth() {
+        let e = makeEntry(name: "Pecho", dates: [date(2026, 5, 30), date(2026, 6, 1), date(2026, 6, 15)])
+        #expect(MonthCalendarCalculator.trainedDayCount(inMonthOf: date(2026, 6, 10), from: [e]) == 2)
+    }
+
+    @Test
+    func testTrainedDayCountIncludesMonthBoundaryDays() {
+        let e = makeEntry(name: "Pecho", dates: [date(2026, 6, 1), date(2026, 6, 30)])
+        #expect(MonthCalendarCalculator.trainedDayCount(inMonthOf: date(2026, 6, 15), from: [e]) == 2)
+    }
+
+    @Test
+    func testTrainedDayCountExcludesFirstOfNextMonth() {
+        // Regression: the 1st of the next month must NOT count toward this month
+        // (DateInterval.contains is end-inclusive — this guards against that).
+        let e = makeEntry(name: "Pecho", dates: [date(2026, 5, 20), date(2026, 6, 1)])
+        #expect(MonthCalendarCalculator.trainedDayCount(inMonthOf: date(2026, 5, 10), from: [e]) == 1)
+    }
+
+    // MARK: - weekBreakdown
+    // (Week of June 10 2026 = Mon June 8 … Sun June 14.)
+
+    @Test
+    func testWeekBreakdownGroupsByDayAndExcludesOtherWeeks() {
+        let pecho = makeEntry(name: "Pecho", dates: [date(2026, 6, 8), date(2026, 6, 12)])
+        let yoga = makeEntry(name: "Yoga", dates: [date(2026, 6, 8)])
+        let nextWeek = makeEntry(name: "Espalda", dates: [date(2026, 6, 16)])
+
+        let result = MonthCalendarCalculator.weekBreakdown(forWeekContaining: date(2026, 6, 10), from: [pecho, yoga, nextWeek])
+        let cal = Date.appCalendar
+
+        #expect(result.count == 2)
+        #expect(cal.component(.day, from: result[0].date) == 8)
+        #expect(result[0].activities.map(\.entry.name) == ["Pecho", "Yoga"]) // sorted by name
+        #expect(cal.component(.day, from: result[1].date) == 12)
+        #expect(result[1].activities.map(\.entry.name) == ["Pecho"])
+    }
+
+    @Test
+    func testWeekBreakdownUsesThatDaysWeightNotLatest() {
+        // Same muscle, different weight each day → each row shows its own day's load.
+        let pecho = MuscleEntry(name: "Pecho")
+        pecho.addSession(date(2026, 6, 8), weight: 50)
+        pecho.addSession(date(2026, 6, 12), weight: 80)
+        let result = MonthCalendarCalculator.weekBreakdown(forWeekContaining: date(2026, 6, 10), from: [pecho])
+        #expect(result[0].activities.first?.weightKg == 50) // Mon 8
+        #expect(result[1].activities.first?.weightKg == 80) // Fri 12
+    }
+
+    @Test
+    func testWeekBreakdownDaysAscending() {
+        let e = makeEntry(name: "Pecho", dates: [date(2026, 6, 12), date(2026, 6, 8)])
+        let result = MonthCalendarCalculator.weekBreakdown(forWeekContaining: date(2026, 6, 10), from: [e])
+        #expect(result.map { Date.appCalendar.component(.day, from: $0.date) } == [8, 12])
+    }
+
+    @Test
+    func testWeekBreakdownEmptyWhenNoActivity() {
+        #expect(MonthCalendarCalculator.weekBreakdown(forWeekContaining: date(2026, 6, 10), from: []).isEmpty)
+    }
+
+    @Test
+    func testWeekBreakdownIncludesDaysAcrossMonthBoundary() {
+        // Week of July 1 2026 (Wed) = Mon June 29 … Sun July 5; entries on both sides.
+        let june = makeEntry(name: "Pecho", dates: [date(2026, 6, 29)])
+        let july = makeEntry(name: "Espalda", dates: [date(2026, 7, 2)])
+        let result = MonthCalendarCalculator.weekBreakdown(forWeekContaining: date(2026, 7, 1), from: [june, july])
+        #expect(result.count == 2)
+    }
+
+    // MARK: - weekdaySymbols
+
+    @Test
+    func testWeekdaySymbolsAreMondayFirst() {
+        let symbols = MonthCalendarCalculator.weekdaySymbols()
+        #expect(symbols.count == 7)
+        #expect(symbols.first == Date.appCalendar.veryShortStandaloneWeekdaySymbols[1]) // Monday
+    }
+}


### PR DESCRIPTION
## Qué

Rediseño del Historial: de una lista plana agrupada por músculo (solo nombre + fecha) a un **calendario mensual** como hero, pensado como pieza de UX que no duplica Stats (agregados) ni Streak (racha).

### Pantalla nueva
- **Calendario mensual** Monday-first, con pager de mes (chevrons), hoy en círculo, y la **semana del día seleccionado resaltada** (recuadro + borde, el look de Calendar.app).
- **Puntos de intensidad** por día: el tamaño/opacidad crece con cuántos músculos entrenaste ese día (mini heatmap).
- **Caption por mes**: "N días entrenados en <mes>" — dato nuevo, no está en Stats/Streak.
- **Detalle por día** de la semana seleccionada: íconos de actividad + **el peso logueado ese día** (no el último — bug que habría mostrado peso equivocado en días pasados).

### Arquitectura
- Nuevo `MonthCalendarCalculator` (struct puro, espeja `StatsCalculator`): matriz de mes (6 filas fijas, sin salto de altura), set de días entrenados, intensidad por día, conteo por mes, desglose de semana con peso por día, símbolos Monday-first. **Único target de tests.**
- 3 vistas nuevas en `Views/calendar/` (`MonthCalendarView`, `CalendarDayCell`, `WeekDetailSection`), cada una con `#Preview`. El resaltado de semana usa 6 `HStack` (no `LazyVGrid`) para la barra contigua.
- `HistoryViewModel` ahora expone paginado + selección y delega al calculator; se borró `groupedEntries`/`weekOf`/`weekRangeString`.

### Bug encontrado y corregido
`DateInterval.contains` es **inclusivo en ambos extremos** → el 1º del mes siguiente se contaba doble (en este mes y el próximo). Cambiado a comparación por mes (`isDate(equalTo:toGranularity:.month)`). Cubierto con test de regresión.

## Tests
- 19 tests nuevos en `MonthCalendarCalculatorTests` (matriz 6×7, offset Monday-first, días de mes adyacente, dedupe por día, intensidad, conteo por mes con bordes, desglose con peso por día).
- `HistoryViewModelTests` migrado a paginado/selección.
- Suite completa: **TEST SUCCEEDED**.

## Verificación visual
Capturado en simulador con datos sembrados (harness temporal, ya revertido): caption, semana resaltada, puntos de intensidad, y detalle con íconos + peso renderizan como en el diseño.

🤖 Generated with [Claude Code](https://claude.com/claude-code)