### PR TITLE
feat: user-defined activity categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ MuscleCheck.xcodeproj/xcuserdata/adjesus.xcuserdatad/xcdebugger/Breakpoints_v2.x
 MuscleCheck/GoogleService-Info.plist
 /GoogleService-Info.plist
 */GoogleService-Info.plist
+.build-dd/

--- a/MuscleCheck/Localizable.xcstrings
+++ b/MuscleCheck/Localizable.xcstrings
@@ -4090,6 +4090,160 @@
           }
         }
       }
+    },
+    "custom_category_add" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Category"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar categoría"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter une catégorie"
+          }
+        }
+      }
+    },
+    "custom_category_empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No custom categories yet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no tienes categorías personalizadas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune catégorie personnalisée"
+          }
+        }
+      }
+    },
+    "custom_category_name_placeholder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Category name"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de la categoría"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom de la catégorie"
+          }
+        }
+      }
+    },
+    "custom_category_section_new" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Category"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nueva categoría"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvelle catégorie"
+          }
+        }
+      }
+    },
+    "custom_category_section_yours" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Categories"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus categorías"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes catégories"
+          }
+        }
+      }
+    },
+    "custom_category_tracks_weight" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Track weight"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registrar peso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suivre le poids"
+          }
+        }
+      }
+    },
+    "settings_custom_categories" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom Categories"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Categorías personalizadas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catégories personnalisées"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/MuscleCheck/MuscleCheckApp.swift
+++ b/MuscleCheck/MuscleCheckApp.swift
@@ -50,6 +50,7 @@ struct MuscleCheckApp: App {
     let schema = Schema([
       MuscleEntry.self,
       ProgressPhoto.self,
+      CustomCategory.self,
     ])
     let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 

--- a/MuscleCheck/Views/AddMuscleGroupView.swift
+++ b/MuscleCheck/Views/AddMuscleGroupView.swift
@@ -11,8 +11,9 @@ import SwiftData
 struct AddMuscleGroupView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.modelContext) var context
+    @Query(sort: \CustomCategory.sortOrder) private var customCategories: [CustomCategory]
     @State private var muscleName: String = ""
-    @State private var selectedCategory: ActivityCategory = .gym
+    @State private var selectedCategoryID: String = ActivityCategory.gym.rawValue
     @State private var selectedIcon: String = ActivityCategory.gym.defaultIcon
     @State private var errorMessage: String?
 
@@ -26,10 +27,14 @@ struct AddMuscleGroupView: View {
                 }
 
                 Section("select_category") {
-                    Picker("select_category", selection: $selectedCategory) {
+                    Picker("select_category", selection: $selectedCategoryID) {
                         ForEach(ActivityCategory.allCases) { category in
                             Label(category.displayName, systemImage: category.defaultIcon)
-                                .tag(category)
+                                .tag(category.rawValue)
+                        }
+                        ForEach(customCategories) { category in
+                            Label(category.name, systemImage: category.icon)
+                                .tag(category.id)
                         }
                     }
                     .pickerStyle(.menu)
@@ -72,8 +77,8 @@ struct AddMuscleGroupView: View {
                 }
             }
             .navigationTitle("add_exercise")
-            .onChange(of: selectedCategory) { _, newCategory in
-                selectedIcon = newCategory.defaultIcon
+            .onChange(of: selectedCategoryID) { _, newID in
+                selectedIcon = CategoryResolver.resolve(newID, custom: customCategories).icon
             }
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
@@ -98,7 +103,7 @@ struct AddMuscleGroupView: View {
         do {
             try MuscleEntryManager(context: context).addEntry(
                 name: muscleName,
-                category: selectedCategory.rawValue,
+                category: selectedCategoryID,
                 icon: selectedIcon
             )
             dismiss()

--- a/MuscleCheck/Views/ContentView.swift
+++ b/MuscleCheck/Views/ContentView.swift
@@ -28,7 +28,8 @@ struct ContentView: View {
   @State private var workoutToLog: IdentifiableWorkout?
 
   @Query private var entries: [MuscleEntry]
-  
+  @Query private var customCategories: [CustomCategory]
+
   var body: some View {
     NavigationStack {
       VStack(spacing: 0) {
@@ -50,6 +51,7 @@ struct ContentView: View {
             ForEach(group.entries) { entry in
               MuscleEntryRowView(
                 entry: entry,
+                customCategories: customCategories,
                 onTap: { _ in viewModel.toggleActivity(for: entry) },
                 onSaveSession: { target, weight, sets, reps in viewModel.saveSession(weight: weight, sets: sets, reps: reps, for: target) }
               )
@@ -64,6 +66,7 @@ struct ContentView: View {
                 ForEach(group.entries) { entry in
                   MuscleEntryRowView(
                     entry: entry,
+                    customCategories: customCategories,
                     onTap: { _ in viewModel.toggleActivity(for: entry) },
                     onSaveSession: { target, weight, sets, reps in viewModel.saveSession(weight: weight, sets: sets, reps: reps, for: target) }
                   )

--- a/MuscleCheck/Views/HistoryView.swift
+++ b/MuscleCheck/Views/HistoryView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct HistoryView: View {
   let entries: [MuscleEntry]
+  @Query private var customCategories: [CustomCategory]
   @StateObject private var viewModel: HistoryViewModel
 
   init(entries: [MuscleEntry]) {
@@ -40,7 +41,7 @@ struct HistoryView: View {
         .padding(.horizontal)
 
         // Selected week, day by day
-        WeekDetailSection(days: viewModel.weekBreakdown)
+        WeekDetailSection(days: viewModel.weekBreakdown, customCategories: customCategories)
       }
       .padding(.vertical)
     }

--- a/MuscleCheck/Views/ManageCategoriesView.swift
+++ b/MuscleCheck/Views/ManageCategoriesView.swift
@@ -1,0 +1,130 @@
+//
+//  ManageCategoriesView.swift
+//  MuscleCheck — Feature: user-defined categories
+//
+//  Lets the user create their own categories beyond the built-in disciplines,
+//  list them and delete them. Persists via CategoryStore. Reuses the icon grid
+//  pattern from AddMuscleGroupView.
+//
+
+import SwiftUI
+import SwiftData
+
+struct ManageCategoriesView: View {
+    @Environment(\.modelContext) private var context
+    @Query(sort: \CustomCategory.sortOrder) private var categories: [CustomCategory]
+
+    @State private var name: String = ""
+    @State private var selectedIcon: String = ActivityCategory.availableIcons.first ?? "star.fill"
+    @State private var tracksWeight: Bool = false
+    @State private var errorMessage: String?
+
+    private let columns = Array(repeating: GridItem(.flexible()), count: 6)
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        Form {
+            // MARK: - New category
+            Section("custom_category_section_new") {
+                TextField("custom_category_name_placeholder", text: $name)
+                Toggle("custom_category_tracks_weight", isOn: $tracksWeight)
+                    .tint(Color.brand)
+            }
+
+            Section("select_icon") {
+                iconGrid
+            }
+
+            if let errorMessage {
+                Section {
+                    Text(errorMessage)
+                        .font(.appSubheadline)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            Section {
+                Button("custom_category_add") { add() }
+                    .disabled(trimmedName.isEmpty)
+            }
+
+            // MARK: - Existing categories
+            Section("custom_category_section_yours") {
+                if categories.isEmpty {
+                    Text("custom_category_empty")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(categories) { category in
+                        HStack {
+                            Image(systemName: category.icon)
+                                .frame(width: 24)
+                                .foregroundStyle(Color.brand)
+                            Text(category.name)
+                            Spacer()
+                            if category.tracksWeight {
+                                Image(systemName: "scalemass")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .onDelete(perform: delete)
+                }
+            }
+        }
+        .navigationTitle("settings_custom_categories")
+        .navigationBarTitleDisplayMode(.inline)
+        .tint(Color.brand)
+    }
+
+    private var iconGrid: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(ActivityCategory.availableIcons, id: \.self) { icon in
+                Button {
+                    selectedIcon = icon
+                } label: {
+                    Image(systemName: icon)
+                        .font(.appTitle3)
+                        .frame(width: 40, height: 40)
+                        .background(selectedIcon == icon ? Color.brand.opacity(0.2) : Color.clear)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .foregroundColor(selectedIcon == icon ? Color.brand : .secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func add() {
+        do {
+            try CategoryStore(context: context).add(
+                name: name,
+                icon: selectedIcon,
+                tracksWeight: tracksWeight
+            )
+            // Reset the form for the next one.
+            name = ""
+            tracksWeight = false
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func delete(at offsets: IndexSet) {
+        let store = CategoryStore(context: context)
+        for index in offsets {
+            try? store.delete(categories[index])
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ManageCategoriesView()
+    }
+    .modelContainer(for: CustomCategory.self, inMemory: true)
+}

--- a/MuscleCheck/Views/MuscleEntryRowView.swift
+++ b/MuscleCheck/Views/MuscleEntryRowView.swift
@@ -10,13 +10,17 @@ import SwiftUI
 
 struct MuscleEntryRowView: View {
     var entry: MuscleEntry
+    /// User-defined categories, so a custom category that opted into weight tracking
+    /// behaves like gym. Defaults to [] — built-ins resolve correctly without it,
+    /// which keeps previews container-free.
+    var customCategories: [CustomCategory] = []
     var onTap: (MuscleEntry) -> Void
     var onSaveSession: (MuscleEntry, Double?, Int?, Int?) -> Void = { _, _, _, _ in }
 
     @State private var isShowingModal: Bool = false
 
     private var canEditWeight: Bool {
-        entry.category == ActivityCategory.gym.rawValue
+        CategoryResolver.resolve(entry.category, custom: customCategories).tracksWeight
     }
 
     var body: some View {

--- a/MuscleCheck/Views/SettingsView.swift
+++ b/MuscleCheck/Views/SettingsView.swift
@@ -85,6 +85,13 @@ struct SettingsView: View {
                     }
                     .disabled(viewModel.addedPresets.contains(category.rawValue))
                 }
+
+                NavigationLink {
+                    ManageCategoriesView()
+                } label: {
+                    Label("settings_custom_categories", systemImage: "folder.badge.plus")
+                        .foregroundColor(Color.brand)
+                }
             }
 
             // MARK: - Units

--- a/MuscleCheck/Views/calendar/WeekDetailSection.swift
+++ b/MuscleCheck/Views/calendar/WeekDetailSection.swift
@@ -10,6 +10,10 @@ import SwiftUI
 /// The per-day breakdown of the selected week, shown below the calendar.
 struct WeekDetailSection: View {
     let days: [DayActivities]
+    /// User-defined categories, forwarded to each row so custom weight-tracking
+    /// categories show their weight in history. Defaults to [] (built-ins resolve
+    /// without it), keeping the preview container-free.
+    var customCategories: [CustomCategory] = []
 
     var body: some View {
         if days.isEmpty {
@@ -27,7 +31,7 @@ struct WeekDetailSection: View {
                             .font(.appSubheadline.bold())
                             .foregroundStyle(Color.brand)
                         ForEach(day.activities) { activity in
-                            ActivityDetailRow(activity: activity)
+                            ActivityDetailRow(activity: activity, customCategories: customCategories)
                         }
                     }
                 }
@@ -57,8 +61,11 @@ struct WeekDetailSection: View {
 /// Deliberately omits the checkmark/weight-edit affordances — history doesn't mutate state.
 private struct ActivityDetailRow: View {
     let activity: DayActivity
+    var customCategories: [CustomCategory] = []
 
-    private var isGym: Bool { activity.entry.category == ActivityCategory.gym.rawValue }
+    private var tracksWeight: Bool {
+        CategoryResolver.resolve(activity.entry.category, custom: customCategories).tracksWeight
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -66,7 +73,7 @@ private struct ActivityDetailRow: View {
                 .foregroundColor(Color.brand)
                 .frame(width: 24)
             Text(activity.entry.name)
-            if isGym, let kg = activity.weightKg {
+            if tracksWeight, let kg = activity.weightKg {
                 Text(formattedWeight(kg))
                     .font(.appCaption)
                     .foregroundStyle(.secondary)

--- a/MuscleCheck/managers/CategoryStore.swift
+++ b/MuscleCheck/managers/CategoryStore.swift
@@ -1,0 +1,72 @@
+//
+//  CategoryStore.swift
+//  MuscleCheck — Feature: user-defined categories
+//
+//  CRUD for user-defined categories over SwiftData, injected with
+//  ModelContextProtocol like the other managers (testable with a real
+//  in-memory context). Ids are UUIDs so they can never collide with a
+//  built-in ActivityCategory rawValue.
+//
+
+import Foundation
+import SwiftData
+
+enum CategoryStoreError: LocalizedError {
+    case invalidName
+    case duplicateName(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidName:
+            return NSLocalizedString("error_invalid_name", comment: "")
+        case .duplicateName(let name):
+            return String(format: NSLocalizedString("error_duplicate_entry %@", comment: ""), name)
+        }
+    }
+}
+
+@MainActor
+final class CategoryStore: CategoryStoreProtocol {
+    private let context: ModelContextProtocol
+
+    init(context: ModelContextProtocol) {
+        self.context = context
+    }
+
+    func fetchAll() throws -> [CustomCategory] {
+        try context.fetch(
+            FetchDescriptor<CustomCategory>(sortBy: [SortDescriptor(\.sortOrder)])
+        )
+    }
+
+    @discardableResult
+    func add(name: String, icon: String, tracksWeight: Bool) throws -> CustomCategory {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw CategoryStoreError.invalidName }
+
+        let existing = try fetchAll()
+        guard !existing.contains(where: { $0.name.caseInsensitiveCompare(trimmed) == .orderedSame }) else {
+            throw CategoryStoreError.duplicateName(trimmed)
+        }
+
+        // Place after the built-ins (sortOrder 0…allCases.count-1) and any existing custom.
+        let nextOrder = (existing.map(\.sortOrder).max() ?? (ActivityCategory.allCases.count - 1)) + 1
+        let category = CustomCategory(
+            id: UUID().uuidString,
+            name: trimmed,
+            icon: icon,
+            sortOrder: nextOrder,
+            tracksWeight: tracksWeight
+        )
+        context.insert(category)
+        try context.save()
+        return category
+    }
+
+    func delete(_ category: CustomCategory) throws {
+        // Entries that referenced this category become orphans; CategoryResolver
+        // degrades them to the neutral "Custom" label, so no crash and no data loss.
+        context.delete(category)
+        try context.save()
+    }
+}

--- a/MuscleCheck/managers/protocols/CategoryStoreProtocol.swift
+++ b/MuscleCheck/managers/protocols/CategoryStoreProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  CategoryStoreProtocol.swift
+//  MuscleCheck — Feature: user-defined categories
+//
+
+import Foundation
+
+@MainActor
+protocol CategoryStoreProtocol {
+    /// All user-defined categories, ordered by `sortOrder` (after the built-ins).
+    func fetchAll() throws -> [CustomCategory]
+
+    /// Creates and persists a custom category. Validates the name and assigns a
+    /// collision-free UUID id and a sortOrder after the built-ins.
+    @discardableResult
+    func add(name: String, icon: String, tracksWeight: Bool) throws -> CustomCategory
+
+    func delete(_ category: CustomCategory) throws
+}

--- a/MuscleCheck/models/ActivityCategory.swift
+++ b/MuscleCheck/models/ActivityCategory.swift
@@ -43,6 +43,11 @@ enum ActivityCategory: String, CaseIterable, Codable, Identifiable, Sendable {
         }
     }
 
+    /// Whether activities in this category prompt for/show weight. Only gym does
+    /// among the built-ins. Replaces the hardcoded `== .gym` checks scattered in
+    /// WorkoutEligibility / MuscleEntryRowView / WeekDetailSection.
+    var tracksWeight: Bool { self == .gym }
+
     var presetEntries: [(nameKey: String, icon: String)] {
         switch self {
         case .gym:

--- a/MuscleCheck/models/CategoryResolver.swift
+++ b/MuscleCheck/models/CategoryResolver.swift
@@ -1,0 +1,55 @@
+//
+//  CategoryResolver.swift
+//  MuscleCheck — Feature: user-defined categories
+//
+//  Single point that turns a stored category string into display info, whether
+//  it came from the built-in ActivityCategory enum or a user-defined
+//  CustomCategory. Pure (takes the custom list as input) so it's trivially
+//  testable and side-effect free. Built-ins always win over a custom with the
+//  same id, so a custom can never shadow a reserved category.
+//
+
+import Foundation
+
+struct ResolvedCategory: Equatable {
+    let id: String
+    let displayName: String
+    let icon: String
+    let tracksWeight: Bool
+    let isBuiltIn: Bool
+}
+
+enum CategoryResolver {
+
+    static func resolve(_ raw: String, custom: [CustomCategory]) -> ResolvedCategory {
+        // 1. Built-in takes precedence — reserved rawValues can't be overridden.
+        if let builtIn = ActivityCategory(rawValue: raw) {
+            return ResolvedCategory(
+                id: raw,
+                displayName: builtIn.displayName,
+                icon: builtIn.defaultIcon,
+                tracksWeight: builtIn.tracksWeight,
+                isBuiltIn: true
+            )
+        }
+        // 2. A user-defined category.
+        if let match = custom.first(where: { $0.id == raw }) {
+            return ResolvedCategory(
+                id: raw,
+                displayName: match.name,
+                icon: match.icon,
+                tracksWeight: match.tracksWeight,
+                isBuiltIn: false
+            )
+        }
+        // 3. Orphan: the custom category was deleted but entries still reference it.
+        //    Degrade gracefully — show the raw string, no weight, a usable icon.
+        return ResolvedCategory(
+            id: raw,
+            displayName: raw,
+            icon: ActivityCategory.custom.defaultIcon,
+            tracksWeight: false,
+            isBuiltIn: false
+        )
+    }
+}

--- a/MuscleCheck/models/CategoryResolver.swift
+++ b/MuscleCheck/models/CategoryResolver.swift
@@ -42,11 +42,12 @@ enum CategoryResolver {
                 isBuiltIn: false
             )
         }
-        // 3. Orphan: the custom category was deleted but entries still reference it.
-        //    Degrade gracefully — show the raw string, no weight, a usable icon.
+        // 3. Orphan: the custom category was deleted but entries still reference its
+        //    (UUID) id. Degrade to the neutral "Custom" label/icon — never echo the
+        //    raw id (it's an opaque UUID), never crash, never track weight.
         return ResolvedCategory(
             id: raw,
-            displayName: raw,
+            displayName: ActivityCategory.custom.displayName,
             icon: ActivityCategory.custom.defaultIcon,
             tracksWeight: false,
             isBuiltIn: false

--- a/MuscleCheck/models/CustomCategory.swift
+++ b/MuscleCheck/models/CustomCategory.swift
@@ -1,0 +1,31 @@
+//
+//  CustomCategory.swift
+//  MuscleCheck — Feature: user-defined categories
+//
+//  A category the user creates beyond the built-in ActivityCategory cases.
+//  `id` is the stable string persisted in MuscleEntry.category (same field that
+//  already stores built-in rawValues), so adding these is ADDITIVE — old entries
+//  are untouched. Built-in rawValues are reserved and must not be used as `id`.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class CustomCategory {
+    @Attribute(.unique) var id: String
+    var name: String
+    var icon: String
+    var sortOrder: Int
+    /// Whether activities in this category prompt for weight (the gym behaviour,
+    /// generalized). Off by default; the user opts in per category.
+    var tracksWeight: Bool
+
+    init(id: String, name: String, icon: String, sortOrder: Int, tracksWeight: Bool = false) {
+        self.id = id
+        self.name = name
+        self.icon = icon
+        self.sortOrder = sortOrder
+        self.tracksWeight = tracksWeight
+    }
+}

--- a/MuscleCheckTests/CategoryResolverTests.swift
+++ b/MuscleCheckTests/CategoryResolverTests.swift
@@ -1,0 +1,82 @@
+//
+//  CategoryResolverTests.swift
+//  MuscleCheck — Feature: user-defined categories
+//
+//  The resolver unifies built-in categories (the ActivityCategory enum) with
+//  user-defined ones (CustomCategory). These tests pin the contract that keeps
+//  PREVIOUS app versions working: any category string an old entry stored must
+//  still resolve, and a deleted custom category must degrade without crashing.
+//
+
+import Testing
+@testable import MuscleCheck
+
+struct CategoryResolverTests {
+
+    private func customCat(
+        _ id: String,
+        name: String = "Custom",
+        icon: String = "star.fill",
+        tracksWeight: Bool = false
+    ) -> CustomCategory {
+        CustomCategory(id: id, name: name, icon: icon, sortOrder: 99, tracksWeight: tracksWeight)
+    }
+
+    @Test
+    func builtInResolvesFromEnum() {
+        let r = CategoryResolver.resolve("gym", custom: [])
+        #expect(r.isBuiltIn)
+        #expect(r.id == "gym")
+        #expect(r.tracksWeight)                       // gym is the weight-tracking category
+        #expect(!r.displayName.isEmpty)
+        #expect(r.icon == ActivityCategory.gym.defaultIcon)
+    }
+
+    @Test
+    func builtInNonGymDoesNotTrackWeight() {
+        let r = CategoryResolver.resolve("yoga", custom: [])
+        #expect(r.isBuiltIn)
+        #expect(!r.tracksWeight)
+    }
+
+    @Test
+    func customResolvesFromStore() {
+        let cat = customCat("escalada", name: "Escalada", icon: "figure.climbing", tracksWeight: true)
+        let r = CategoryResolver.resolve("escalada", custom: [cat])
+        #expect(!r.isBuiltIn)
+        #expect(r.id == "escalada")
+        #expect(r.displayName == "Escalada")
+        #expect(r.icon == "figure.climbing")
+        #expect(r.tracksWeight)
+    }
+
+    @Test
+    func builtInWinsOverCustomWithSameId() {
+        // A custom category must never shadow a built-in rawValue.
+        let shadow = customCat("gym", name: "Hacked", tracksWeight: false)
+        let r = CategoryResolver.resolve("gym", custom: [shadow])
+        #expect(r.isBuiltIn)
+        #expect(r.tracksWeight)                       // still the real gym, not the shadow
+    }
+
+    @Test
+    func orphanStringFallsBackGracefully() {
+        // Category whose CustomCategory was deleted: must not crash, must degrade sanely.
+        let r = CategoryResolver.resolve("deleted-cat", custom: [])
+        #expect(!r.isBuiltIn)
+        #expect(r.id == "deleted-cat")
+        #expect(r.displayName == "deleted-cat")       // shows the raw string, not empty
+        #expect(!r.tracksWeight)
+        #expect(!r.icon.isEmpty)                      // always a usable icon
+    }
+
+    @Test
+    func oldEntryCategoryStillResolves() {
+        // Back-compat: an entry saved by a previous app version resolves identically.
+        for category in ActivityCategory.allCases {
+            let r = CategoryResolver.resolve(category.rawValue, custom: [])
+            #expect(r.isBuiltIn)
+            #expect(r.id == category.rawValue)
+        }
+    }
+}

--- a/MuscleCheckTests/CategoryResolverTests.swift
+++ b/MuscleCheckTests/CategoryResolverTests.swift
@@ -62,10 +62,11 @@ struct CategoryResolverTests {
     @Test
     func orphanStringFallsBackGracefully() {
         // Category whose CustomCategory was deleted: must not crash, must degrade sanely.
-        let r = CategoryResolver.resolve("deleted-cat", custom: [])
+        let r = CategoryResolver.resolve("DEAD-BEEF-UUID", custom: [])
         #expect(!r.isBuiltIn)
-        #expect(r.id == "deleted-cat")
-        #expect(r.displayName == "deleted-cat")       // shows the raw string, not empty
+        #expect(r.id == "DEAD-BEEF-UUID")             // preserves the id (for round-tripping)
+        #expect(!r.displayName.isEmpty)               // neutral label, never the raw UUID
+        #expect(r.displayName != "DEAD-BEEF-UUID")    // must NOT echo the opaque id
         #expect(!r.tracksWeight)
         #expect(!r.icon.isEmpty)                      // always a usable icon
     }

--- a/MuscleCheckTests/CategoryStoreTests.swift
+++ b/MuscleCheckTests/CategoryStoreTests.swift
@@ -1,0 +1,75 @@
+//
+//  CategoryStoreTests.swift
+//  MuscleCheck — Feature: user-defined categories
+//
+//  Uses a real in-memory SwiftData context (ModelContext conforms to
+//  ModelContextProtocol), which also proves CustomCategory is wired into a
+//  working store.
+//
+
+import Testing
+import SwiftData
+@testable import MuscleCheck
+
+@MainActor
+struct CategoryStoreTests {
+
+    private func makeStore() throws -> CategoryStore {
+        let container = try ModelContainer(
+            for: CustomCategory.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return CategoryStore(context: ModelContext(container))
+    }
+
+    @Test
+    func addPersistsAndFetchReturnsIt() throws {
+        let store = try makeStore()
+        let cat = try store.add(name: "Escalada", icon: "figure.climbing", tracksWeight: false)
+        let all = try store.fetchAll()
+        #expect(all.count == 1)
+        #expect(all.first?.id == cat.id)
+        #expect(all.first?.name == "Escalada")
+    }
+
+    @Test
+    func addTrimsAndRejectsEmptyName() throws {
+        let store = try makeStore()
+        #expect(throws: CategoryStoreError.self) {
+            try store.add(name: "   ", icon: "star.fill", tracksWeight: false)
+        }
+    }
+
+    @Test
+    func addRejectsDuplicateNameCaseInsensitive() throws {
+        let store = try makeStore()
+        try store.add(name: "Escalada", icon: "x", tracksWeight: false)
+        #expect(throws: CategoryStoreError.self) {
+            try store.add(name: "escalada", icon: "y", tracksWeight: false)
+        }
+    }
+
+    @Test
+    func customIdsAreUniqueAndNeverShadowBuiltIns() throws {
+        let store = try makeStore()
+        let a = try store.add(name: "A", icon: "x", tracksWeight: false)
+        let b = try store.add(name: "B", icon: "y", tracksWeight: true)
+        #expect(a.id != b.id)
+        #expect(ActivityCategory(rawValue: a.id) == nil)   // a UUID is never a built-in rawValue
+    }
+
+    @Test
+    func sortOrderComesAfterBuiltIns() throws {
+        let store = try makeStore()
+        let a = try store.add(name: "A", icon: "x", tracksWeight: false)
+        #expect(a.sortOrder >= ActivityCategory.allCases.count)
+    }
+
+    @Test
+    func deleteRemovesIt() throws {
+        let store = try makeStore()
+        let cat = try store.add(name: "Tmp", icon: "x", tracksWeight: false)
+        try store.delete(cat)
+        #expect(try store.fetchAll().isEmpty)
+    }
+}


### PR DESCRIPTION
Categorías de actividad **definidas por el usuario**, más allá de las 7 built-in. Diseñado test-first y aditivo para no romper versiones anteriores.

## Qué hace
- El usuario crea categorías propias (nombre + ícono + toggle "registrar peso") en **Settings → Activity Presets → Custom Categories**.
- Las custom aparecen en el picker de alta de actividades.
- Una custom con "registrar peso" se comporta como gym (muestra/edita peso).

## Arquitectura
- `CustomCategory` (`@Model`) cuyo `id` es el mismo string que ya guarda `MuscleEntry.category` → **migración aditiva**, entries viejas intactas.
- `CategoryResolver` (puro): unifica built-in (enum) + custom; built-in siempre gana; categoría borrada degrada a "Custom" sin crashear.
- `CategoryStore` (CRUD sobre `ModelContextProtocol`, ids UUID anti-colisión, validación, orden post built-ins).
- `ActivityCategory.tracksWeight` reemplaza los `== .gym` hardcodeados en `MuscleEntryRowView` / `WeekDetailSection`. El AI Coach se deja gym-only (es por diseño, no por peso).
- Widget sin cambios (renderiza ícono+nombre por entry).
- Strings ES/EN/FR.

## Verificación
- **12 unit tests nuevos** (resolver + store) verdes; suite unit completo verde.
- `SessionLogUITests` verdes (regresión del modal de peso gym tras el refactor).
- App arranca y renderiza con el schema nuevo (back-compat confirmada en sim).

## Decisiones abiertas (revisar)
- Categorías custom empiezan vacías (como `.custom`).
- Borrar categoría no borra entries (quedan huérfanas → "Custom", no-destructivo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
