### PR TITLE
fix: 'could not open default.store' — share one SwiftData schema across both containers

### DIFF
--- a/MuscleCheck/AppIntents/MuscleDataActor.swift
+++ b/MuscleCheck/AppIntents/MuscleDataActor.swift
@@ -9,9 +9,11 @@ import SwiftData
 @ModelActor
 actor MuscleDataActor {
 
+    // Shares AppSchema with MuscleCheckApp — both open the same default.store, so the
+    // entity sets must match or SwiftData refuses to open it ("could not open default.store").
     static let sharedContainer: ModelContainer = {
         do {
-            return try ModelContainer(for: MuscleEntry.self, ProgressPhoto.self)
+            return try ModelContainer(for: AppSchema.schema)
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")
         }

--- a/MuscleCheck/MuscleCheckApp.swift
+++ b/MuscleCheck/MuscleCheckApp.swift
@@ -47,11 +47,7 @@ struct MuscleCheckApp: App {
   }
   
   var sharedModelContainer: ModelContainer = {
-    let schema = Schema([
-      MuscleEntry.self,
-      ProgressPhoto.self,
-      CustomCategory.self,
-    ])
+    let schema = AppSchema.schema
     let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
     do {

--- a/MuscleCheck/models/AppSchema.swift
+++ b/MuscleCheck/models/AppSchema.swift
@@ -1,0 +1,22 @@
+//
+//  AppSchema.swift
+//  MuscleCheck
+//
+//  Single source of truth for the SwiftData entity set. BOTH containers that open
+//  the app's `default.store` MUST use this — the main app (MuscleCheckApp) and the
+//  App Intents actor (MuscleDataActor). A mismatched entity set between two containers
+//  on the same store makes SwiftData refuse to open it ("could not open default.store").
+//  Adding a new @Model = add it here, and both containers pick it up.
+//
+
+import SwiftData
+
+enum AppSchema {
+    static let models: [any PersistentModel.Type] = [
+        MuscleEntry.self,
+        ProgressPhoto.self,
+        CustomCategory.self,
+    ]
+
+    static var schema: Schema { Schema(models) }
+}

--- a/MuscleCheckTests/CategoryMigrationTests.swift
+++ b/MuscleCheckTests/CategoryMigrationTests.swift
@@ -1,0 +1,68 @@
+//
+//  CategoryMigrationTests.swift
+//  MuscleCheck — Feature: user-defined categories
+//
+//  Reproduces the device-only failure ("No se ha podido abrir el archivo
+//  default.store") when upgrading from a store created WITHOUT CustomCategory
+//  (a previous app version) to one WITH it, at the SAME on-disk url. A fresh
+//  in-memory store never migrates — which is why CategoryStoreTests missed this.
+//
+
+import Testing
+import SwiftData
+import Foundation
+@testable import MuscleCheck
+
+@MainActor
+struct CategoryMigrationTests {
+
+    @Test
+    func addingCustomCategoryEntityMigratesExistingStore() throws {
+        let url = URL.temporaryDirectory.appending(path: "mig-\(UUID().uuidString).store")
+        defer {
+            for suffix in ["", "-wal", "-shm"] {
+                try? FileManager.default.removeItem(at: URL(fileURLWithPath: url.path + suffix))
+            }
+        }
+
+        // 1. OLD schema: MuscleEntry + ProgressPhoto, no CustomCategory.
+        do {
+            let oldSchema = Schema([MuscleEntry.self, ProgressPhoto.self])
+            let container = try ModelContainer(
+                for: oldSchema,
+                configurations: ModelConfiguration(schema: oldSchema, url: url)
+            )
+            let ctx = ModelContext(container)
+            ctx.insert(MuscleEntry(name: "Pecho"))
+            try ctx.save()
+        }
+
+        // 2. NEW schema adds CustomCategory at the SAME url → migration happens here.
+        let newSchema = Schema([MuscleEntry.self, ProgressPhoto.self, CustomCategory.self])
+        let container = try ModelContainer(
+            for: newSchema,
+            configurations: ModelConfiguration(schema: newSchema, url: url)
+        )
+        let ctx = ModelContext(container)
+
+        // 3. Pre-existing data survived the migration.
+        #expect(try ctx.fetch(FetchDescriptor<MuscleEntry>()).count == 1)
+
+        // 4. Inserting a CustomCategory must work — this is exactly where the device failed.
+        ctx.insert(CustomCategory(id: UUID().uuidString, name: "Escalada", icon: "figure.climbing", sortOrder: 8))
+        try ctx.save()
+        #expect(try ctx.fetch(FetchDescriptor<CustomCategory>()).count == 1)
+    }
+
+    @Test
+    func appIntentsContainerSharesTheFullSchema() {
+        // Regression: MuscleDataActor (App Intents / Siri) opened the SAME default.store
+        // with a stale 2-entity schema (missing CustomCategory). Two containers with
+        // different entity sets on one store → "could not open default.store" on upgraded
+        // devices. Both must declare AppSchema's entities.
+        let actorEntities = Set(MuscleDataActor.sharedContainer.schema.entities.map(\.name))
+        let appEntities = Set(AppSchema.schema.entities.map(\.name))
+        #expect(actorEntities == appEntities)
+        #expect(actorEntities.contains("CustomCategory"))
+    }
+}


### PR DESCRIPTION
El App Intents actor (MuscleDataActor) abría el mismo default.store con un schema de 2 entidades (sin CustomCategory) mientras el container principal tenía 3 → SwiftData rechaza abrir el store en devices actualizados (el error que reportó el tester en pantalla).

Fix: AppSchema como fuente única de verdad, usada por ambos containers — no puede volver a desincronizarse. Tests: migración de store upgrade + regresión que verifica que el container de App Intents comparte el schema completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)