### PR TITLE
fix: custom category section showed its UUID instead of its name

### DIFF
--- a/MuscleCheck/Views/ContentView.swift
+++ b/MuscleCheck/Views/ContentView.swift
@@ -233,18 +233,16 @@ struct ContentView: View {
     }
   }
 
-  @ViewBuilder
   private func categoryHeader(_ categoryRaw: String) -> some View {
-    if let category = ActivityCategory(rawValue: categoryRaw) {
-      HStack(spacing: 6) {
-        Image(systemName: category.defaultIcon)
-        Text(category.displayName)
-      }
-      .font(.appSubheadline.bold())
-      .foregroundColor(Color.brand)
-    } else {
-      Text(categoryRaw)
+    // Resolve through CategoryResolver so custom categories show their name + icon —
+    // a raw category string here is a custom category's UUID, never a display label.
+    let resolved = CategoryResolver.resolve(categoryRaw, custom: customCategories)
+    return HStack(spacing: 6) {
+      Image(systemName: resolved.icon)
+      Text(resolved.displayName)
     }
+    .font(.appSubheadline.bold())
+    .foregroundColor(Color.brand)
   }
 }
 

--- a/MuscleCheck/viewModels/ContentViewModel.swift
+++ b/MuscleCheck/viewModels/ContentViewModel.swift
@@ -152,9 +152,13 @@ final class ContentViewModel: ObservableObject {
           let grouped = Dictionary(grouping: currentWeekEntries) { $0.category }
           groupedCurrentWeekEntries = grouped
               .sorted { lhs, rhs in
+                  // Built-ins keep their declared order; custom categories (no enum match)
+                  // share the trailing bucket, so break ties on the key for a STABLE order
+                  // — Swift's sort isn't stable, and without this several customs jittered.
                   let lOrder = ActivityCategory(rawValue: lhs.key)?.sortOrder ?? 99
                   let rOrder = ActivityCategory(rawValue: rhs.key)?.sortOrder ?? 99
-                  return lOrder < rOrder
+                  if lOrder != rOrder { return lOrder < rOrder }
+                  return lhs.key < rhs.key
               }
               .map { (category: $0.key, entries: $0.value) }
 


### PR DESCRIPTION
categoryHeader mostraba el string crudo (UUID) para categorías custom. Resuelto vía CategoryResolver (nombre + ícono). Bonus: desempate estable en el sort de categorías para que varias custom no salten de orden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)