### PR TITLE
feat(onboarding): first-run welcome + category picker with contextual tips

### DIFF
--- a/MuscleCheck.xcodeproj/project.pbxproj
+++ b/MuscleCheck.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 				CODE_SIGN_ENTITLEMENTS = MuscleCheckWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = DTJLZH295U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MuscleCheckWidget/Info.plist;
@@ -491,7 +491,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zadkiel.musclecheck.MuscleCheckWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -512,7 +512,7 @@
 				CODE_SIGN_ENTITLEMENTS = MuscleCheckWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = DTJLZH295U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MuscleCheckWidget/Info.plist;
@@ -524,7 +524,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zadkiel.musclecheck.MuscleCheckWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -666,7 +666,7 @@
 				CODE_SIGN_ENTITLEMENTS = MuscleCheck/MuscleCheck.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"MuscleCheck/Preview Content\"";
 				DEVELOPMENT_TEAM = DTJLZH295U;
@@ -685,7 +685,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -711,7 +711,7 @@
 				CODE_SIGN_ENTITLEMENTS = MuscleCheck/MuscleCheck.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MuscleCheck/Preview Content\"";
 				DEVELOPMENT_TEAM = DTJLZH295U;
 				ENABLE_PREVIEWS = YES;
@@ -729,7 +729,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/MuscleCheck/Localizable.xcstrings
+++ b/MuscleCheck/Localizable.xcstrings
@@ -1,6 +1,383 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "onboarding_picker_cta" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create My List"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear mi lista"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer ma liste"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea la mia lista"
+          }
+        }
+      }
+    },
+    "onboarding_picker_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick one or more — you can change everything later."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige una o varias; puedes cambiarlo todo después."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez-en une ou plusieurs — vous pourrez tout modifier plus tard."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegline una o più: potrai cambiare tutto in seguito."
+          }
+        }
+      }
+    },
+    "onboarding_picker_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What do you want to track?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Qué quieres registrar?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Que voulez-vous suivre ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cosa vuoi tracciare?"
+          }
+        }
+      }
+    },
+    "onboarding_skip" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Omitir"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salta"
+          }
+        }
+      }
+    },
+    "onboarding_welcome_body" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick your activities and check them off when you train. The list starts fresh every Monday."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige tus actividades y márcalas cuando entrenes. La lista se renueva cada lunes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez vos activités et cochez-les quand vous vous entraînez. La liste repart à zéro chaque lundi."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli le tue attività e spuntale quando ti alleni. La lista riparte da capo ogni lunedì."
+          }
+        }
+      }
+    },
+    "onboarding_welcome_cta" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get Started"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empezar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commencer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inizia"
+          }
+        }
+      }
+    },
+    "onboarding_welcome_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Track your training in 2 seconds"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registra tu entrenamiento en 2 segundos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suivez votre entraînement en 2 secondes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traccia il tuo allenamento in 2 secondi"
+          }
+        }
+      }
+    },
+    "tip_check_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the circle to check it off. That's the whole workflow."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca el círculo para marcarlo. Eso es todo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Touchez le cercle pour cocher. C'est tout."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tocca il cerchio per spuntare. Tutto qui."
+          }
+        }
+      }
+    },
+    "tip_check_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trained today?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Entrenaste hoy?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entraînement fait ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ti sei allenato oggi?"
+          }
+        }
+      }
+    },
+    "tip_reset_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checks reset every Monday. Your history keeps everything you logged."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las marcas se reinician cada lunes. Tu historial guarda todo lo que registraste."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les coches se réinitialisent chaque lundi. Votre historique conserve tout."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le spunte si azzerano ogni lunedì. La cronologia conserva tutto."
+          }
+        }
+      }
+    },
+    "tip_reset_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New week, fresh list"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semana nueva, lista nueva"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvelle semaine, nouvelle liste"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuova settimana, nuova lista"
+          }
+        }
+      }
+    },
+    "tip_weight_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the name of a gym activity to log weight, sets and reps."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca el nombre de una actividad de gym para registrar peso, series y repeticiones."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Touchez le nom d'une activité de muscu pour noter le poids, les séries et les répétitions."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tocca il nome di un'attività di palestra per registrare peso, serie e ripetizioni."
+          }
+        }
+      }
+    },
+    "tip_weight_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log the weight"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registra el peso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notez le poids"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registra il peso"
+          }
+        }
+      }
+    },
     "–" : {
       "comment" : "A placeholder for a value that is not set.",
       "isCommentAutoGenerated" : true

--- a/MuscleCheck/MuscleCheckApp.swift
+++ b/MuscleCheck/MuscleCheckApp.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftData
 import Firebase
+import TipKit
 
 @main
 struct MuscleCheckApp: App {
@@ -18,9 +19,27 @@ struct MuscleCheckApp: App {
   init() {
     setNavalBarAppearance()
 
+    // UI-test hook: forces the first-run experience on an already-installed build
+    // (persisted flags would otherwise skip onboarding on every run after the first).
+    if UserDefaults.standard.bool(forKey: "resetOnboarding") {
+      UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
+      UserDefaults.standard.removeObject(forKey: "defaultEntriesCreated")
+      try? Tips.resetDatastore()
+    }
+
+    // Before the first body evaluation, so pre-onboarding users never see the
+    // welcome cover flash.
+    UserDefaultsManager.shared.migrateOnboardingFlagIfNeeded()
+
     FirebaseApp.configure()
     StoreManager.shared.configure()
     MuscleCheckShortcuts.updateAppShortcutParameters()
+
+    // UI tests pass -uiTesting (arguments domain): unconfigured TipKit never shows
+    // tips, so popovers can't sit on top of the rows the tests need to tap.
+    if !UserDefaults.standard.bool(forKey: "uiTesting") {
+      try? Tips.configure()
+    }
   }
   
   private func setNavalBarAppearance() {

--- a/MuscleCheck/Views/ContentView.swift
+++ b/MuscleCheck/Views/ContentView.swift
@@ -7,6 +7,7 @@
 import SwiftUI
 import SwiftData
 import HealthKit
+import TipKit
 
 struct ContentView: View {
   
@@ -17,11 +18,12 @@ struct ContentView: View {
   @EnvironmentObject var settingsViewModel: SettingsViewModel
   @Environment(\.modelContext) private var context
   @Environment(\.scenePhase) private var scenePhase
-  @AppStorage("hasInsertedInitialData") private var hasInsertedInitialData: Bool = false
-  
+  // Same key UserDefaultsManager owns; @AppStorage so the cover dismisses reactively
+  // when OnboardingViewModel flips the flag.
+  @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding: Bool = false
+
   @State private var showingRoutineModal = false
   @State private var showingAddSheet = false
-  @State private var showingPaywall = false
   @State private var showingSettings = false
   @State private var showingStats = false
   @State private var showingProgressPhotos = false
@@ -46,6 +48,11 @@ struct ContentView: View {
           .padding(.top, 4)
         }
 
+        // First time a weekly reset clears the checks, explain the mental model
+        // ("fresh list every Monday") right where the checks just disappeared.
+        TipView(WeeklyResetTip())
+          .padding(.horizontal)
+
         List {
           if viewModel.currentWeekEntries.isEmpty {
             EmptyStateView()
@@ -53,12 +60,7 @@ struct ContentView: View {
             // Single category — no section headers for clean look
             let group = viewModel.groupedCurrentWeekEntries[0]
             ForEach(group.entries) { entry in
-              MuscleEntryRowView(
-                entry: entry,
-                customCategories: customCategories,
-                onTap: { _ in viewModel.toggleActivity(for: entry) },
-                onSaveSession: { target, weight, sets, reps in viewModel.saveSession(weight: weight, sets: sets, reps: reps, for: target) }
-              )
+              entryRow(entry)
             }
             .onDelete { offsets in
               viewModel.deleteEntries(from: group.entries, at: offsets)
@@ -68,12 +70,7 @@ struct ContentView: View {
             ForEach(viewModel.groupedCurrentWeekEntries, id: \.category) { group in
               Section {
                 ForEach(group.entries) { entry in
-                  MuscleEntryRowView(
-                    entry: entry,
-                    customCategories: customCategories,
-                    onTap: { _ in viewModel.toggleActivity(for: entry) },
-                    onSaveSession: { target, weight, sets, reps in viewModel.saveSession(weight: weight, sets: sets, reps: reps, for: target) }
-                  )
+                  entryRow(entry)
                 }
                 .onDelete { offsets in
                   viewModel.deleteEntries(from: group.entries, at: offsets)
@@ -219,7 +216,41 @@ struct ContentView: View {
           healthKitManager.dismissWorkout(item.workout)
         }
       }
+      // First run only: the initial seed is decided inside (category picker).
+      // Dismisses itself when OnboardingViewModel flips hasCompletedOnboarding.
+      .fullScreenCover(isPresented: Binding(
+        get: { !hasCompletedOnboarding },
+        set: { hasCompletedOnboarding = !$0 }
+      )) {
+        OnboardingView()
+      }
     }
+  }
+
+  /// Shared row construction for both list layouts. The tip flags mark exactly one
+  /// row app-wide as the anchor for each onboarding tip.
+  private func entryRow(_ entry: MuscleEntry) -> some View {
+    MuscleEntryRowView(
+      entry: entry,
+      customCategories: customCategories,
+      showsCheckTip: entry.persistentModelID == checkTipEntryID,
+      showsWeightTip: entry.persistentModelID == weightTipEntryID,
+      onTap: { _ in viewModel.toggleActivity(for: entry) },
+      onSaveSession: { target, weight, sets, reps in viewModel.saveSession(weight: weight, sets: sets, reps: reps, for: target) }
+    )
+  }
+
+  /// First visible row — anchor for the "tap the circle when you train" tip.
+  private var checkTipEntryID: PersistentIdentifier? {
+    viewModel.groupedCurrentWeekEntries.first?.entries.first?.persistentModelID
+  }
+
+  /// First row of the first weight-tracking (gym) category — anchor for the
+  /// "tap the name to log weight" tip. Built-ins only: the tip copy is gym-worded.
+  private var weightTipEntryID: PersistentIdentifier? {
+    viewModel.groupedCurrentWeekEntries
+      .first { ActivityCategory(rawValue: $0.category)?.tracksWeight == true }?
+      .entries.first?.persistentModelID
   }
 
   /// Entries in the same category as the workout — the picker's options.

--- a/MuscleCheck/Views/MuscleEntryRowView.swift
+++ b/MuscleCheck/Views/MuscleEntryRowView.swift
@@ -7,6 +7,7 @@
 
 
 import SwiftUI
+import TipKit
 
 struct MuscleEntryRowView: View {
     var entry: MuscleEntry
@@ -14,10 +15,17 @@ struct MuscleEntryRowView: View {
     /// behaves like gym. Defaults to [] — built-ins resolve correctly without it,
     /// which keeps previews container-free.
     var customCategories: [CustomCategory] = []
+    /// Tip anchors: ContentView marks exactly one row per tip (first row overall /
+    /// first weight-tracking row) so the popovers don't repeat on every row.
+    var showsCheckTip: Bool = false
+    var showsWeightTip: Bool = false
     var onTap: (MuscleEntry) -> Void
     var onSaveSession: (MuscleEntry, Double?, Int?, Int?) -> Void = { _, _, _, _ in }
 
     @State private var isShowingModal: Bool = false
+
+    private let checkTip = CheckActivityTip()
+    private let weightTip = LogWeightTip()
 
     private var canEditWeight: Bool {
         CategoryResolver.resolve(entry.category, custom: customCategories).tracksWeight
@@ -25,47 +33,63 @@ struct MuscleEntryRowView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            // One tap target for the whole row (except the checkmark): opens the weight
-            // modal for gym entries. Avoids the dead/ambiguous zones between icon and name.
-            HStack {
-                // Icon in a soft tinted tile (Settings/Things-style) — adds depth and reads
-                // as designed rather than a flat coloured glyph. Ready to colour per category.
-                Image(systemName: entry.icon)
-                    .font(.appSubheadline)
-                    .foregroundStyle(Color.brand)
-                    .frame(width: 32, height: 32)
-                    .background(Color.brand.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
-                    .padding(.trailing, 4)
-                Text(entry.name)
-                if canEditWeight, let weightLabel = entry.formattedLastWeight {
-                    Text(weightLabel)
-                        .font(.appCaption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: 8)
-            }
-            .contentShape(Rectangle())
-            .onTapGesture {
-                guard canEditWeight else { return }
-                isShowingModal = true
+            if showsWeightTip {
+                rowBody.popoverTip(weightTip)
+            } else {
+                rowBody
             }
 
-            // Isolated tap target. `.plain` style is required: without it, a Button inside
-            // a List row makes the ENTIRE row toggle, so any stray tap flipped the check.
-            Button {
-                onTap(entry)
-            } label: {
-                Image(systemName: entry.isChecked ? "checkmark.circle.fill" : "circle")
-                    .foregroundColor(entry.isChecked ? .success : .gray)
-                    .padding(.leading, 8)
-                    .contentShape(Rectangle())
+            if showsCheckTip {
+                checkButton.popoverTip(checkTip)
+            } else {
+                checkButton
             }
-            .buttonStyle(.plain)
         }
         .sheet(isPresented: $isShowingModal) {
             SessionLogView(entry: entry) { newWeight, newSets, newReps in
                 onSaveSession(entry, newWeight, newSets, newReps)
             }
         }
+    }
+
+    // One tap target for the whole row (except the checkmark): opens the weight
+    // modal for gym entries. Avoids the dead/ambiguous zones between icon and name.
+    private var rowBody: some View {
+        HStack {
+            // Icon in a soft tinted tile (Settings/Things-style) — adds depth and reads
+            // as designed rather than a flat coloured glyph. Ready to colour per category.
+            Image(systemName: entry.icon)
+                .font(.appSubheadline)
+                .foregroundStyle(Color.brand)
+                .frame(width: 32, height: 32)
+                .background(Color.brand.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+                .padding(.trailing, 4)
+            Text(entry.name)
+            if canEditWeight, let weightLabel = entry.formattedLastWeight {
+                Text(weightLabel)
+                    .font(.appCaption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard canEditWeight else { return }
+            isShowingModal = true
+        }
+    }
+
+    // Isolated tap target. `.plain` style is required: without it, a Button inside
+    // a List row makes the ENTIRE row toggle, so any stray tap flipped the check.
+    private var checkButton: some View {
+        Button {
+            onTap(entry)
+        } label: {
+            Image(systemName: entry.isChecked ? "checkmark.circle.fill" : "circle")
+                .foregroundColor(entry.isChecked ? .success : .gray)
+                .padding(.leading, 8)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/MuscleCheck/Views/onboarding/OnboardingView.swift
+++ b/MuscleCheck/Views/onboarding/OnboardingView.swift
@@ -1,0 +1,211 @@
+//
+//  OnboardingView.swift
+//  MuscleCheck
+//
+//  Two screens, zero permissions, zero paywall: show the mental model, personalize
+//  the initial checklist, get out of the way. Everything else is taught in context
+//  via TipKit (see AppTips.swift).
+//
+
+import SwiftUI
+import SwiftData
+
+struct OnboardingView: View {
+    @Environment(\.modelContext) private var context
+    @StateObject private var viewModel = OnboardingViewModel()
+    @State private var step: Step = .welcome
+
+    private enum Step { case welcome, picker }
+
+    var body: some View {
+        ZStack {
+            switch step {
+            case .welcome:
+                WelcomeStepView {
+                    withAnimation(.easeInOut) { step = .picker }
+                }
+                .transition(.asymmetric(
+                    insertion: .identity,
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                ))
+            case .picker:
+                CategoryPickerStepView(
+                    viewModel: viewModel,
+                    onContinue: { viewModel.completeOnboarding(context: context) },
+                    onSkip: { viewModel.skipOnboarding(context: context) }
+                )
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+        }
+        .background(Color(.systemBackground))
+    }
+}
+
+// MARK: - Step 1: Welcome
+
+private struct WelcomeStepView: View {
+    var onContinue: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            demoChecklist
+                .padding(.bottom, 40)
+
+            Text("onboarding_welcome_title")
+                .font(.appTitle.bold())
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 12)
+
+            Text("onboarding_welcome_body")
+                .font(.appBody)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            Spacer()
+            Spacer()
+
+            Button {
+                onContinue()
+            } label: {
+                Text("onboarding_welcome_cta")
+                    .fontWeight(.medium)
+                    .padding(.vertical, 10)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.brand)
+            .accessibilityIdentifier("onboarding.start")
+        }
+        .padding(24)
+    }
+
+    /// Non-interactive mini checklist in the app's own row language: shows the core
+    /// loop (activity → check) and that this isn't gym-only, without a word of copy.
+    private var demoChecklist: some View {
+        VStack(spacing: 14) {
+            demoRow(.gym, checked: true)
+            demoRow(.yoga, checked: false)
+            demoRow(.running, checked: false)
+        }
+        .padding(16)
+        .background(Color(.systemGray6), in: RoundedRectangle(cornerRadius: 16))
+        .accessibilityHidden(true)
+    }
+
+    private func demoRow(_ category: ActivityCategory, checked: Bool) -> some View {
+        HStack {
+            Image(systemName: category.defaultIcon)
+                .font(.appSubheadline)
+                .foregroundStyle(Color.brand)
+                .frame(width: 32, height: 32)
+                .background(Color.brand.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+                .padding(.trailing, 4)
+            Text(category.displayName)
+            Spacer(minLength: 24)
+            Image(systemName: checked ? "checkmark.circle.fill" : "circle")
+                .foregroundColor(checked ? .success : .gray)
+        }
+    }
+}
+
+// MARK: - Step 2: Category picker
+
+private struct CategoryPickerStepView: View {
+    @ObservedObject var viewModel: OnboardingViewModel
+    var onContinue: () -> Void
+    var onSkip: () -> Void
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 2)
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("onboarding_picker_title")
+                .font(.appTitle2.bold())
+                .multilineTextAlignment(.center)
+                .padding(.top, 32)
+                .padding(.bottom, 8)
+
+            Text("onboarding_picker_subtitle")
+                .font(.appSubheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 20)
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 12) {
+                    ForEach(viewModel.selectableCategories) { category in
+                        categoryCard(category)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+
+            Button {
+                onContinue()
+            } label: {
+                Text("onboarding_picker_cta")
+                    .fontWeight(.medium)
+                    .padding(.vertical, 10)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.brand)
+            .disabled(!viewModel.canContinue)
+            .accessibilityIdentifier("onboarding.createList")
+            .padding(.top, 12)
+
+            Button("onboarding_skip") {
+                onSkip()
+            }
+            .font(.appSubheadline)
+            .foregroundStyle(.secondary)
+            .accessibilityIdentifier("onboarding.skip")
+            .padding(.top, 12)
+        }
+        .padding(24)
+    }
+
+    private func categoryCard(_ category: ActivityCategory) -> some View {
+        let isSelected = viewModel.selectedCategories.contains(category)
+        return Button {
+            viewModel.toggle(category)
+        } label: {
+            VStack(spacing: 8) {
+                Image(systemName: category.defaultIcon)
+                    .font(.appTitle2)
+                Text(category.displayName)
+                    .font(.appSubheadline)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, minHeight: 92)
+            .background(
+                isSelected ? Color.brand.opacity(0.15) : Color(.systemGray6),
+                in: RoundedRectangle(cornerRadius: 12)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(isSelected ? Color.brand : .clear, lineWidth: 1.5)
+            )
+            .overlay(alignment: .topTrailing) {
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(Color.brand)
+                        .padding(8)
+                }
+            }
+            .foregroundStyle(isSelected ? Color.brand : .primary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("onboarding.category.\(category.rawValue)")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+#Preview {
+    OnboardingView()
+        .modelContainer(for: MuscleEntry.self, inMemory: true)
+}

--- a/MuscleCheck/managers/AppTips.swift
+++ b/MuscleCheck/managers/AppTips.swift
@@ -1,0 +1,46 @@
+//
+//  AppTips.swift
+//  MuscleCheck
+//
+//  Onboarding is deliberately two screens; everything about HOW the app works is
+//  taught here, in context, the first time each moment happens (progressive
+//  disclosure). Every tip shows at most once.
+//
+
+import TipKit
+
+/// Anchored to the check circle of the first row right after onboarding: the one
+/// interaction the whole app is built around. Invalidated on the first toggle.
+struct CheckActivityTip: Tip {
+    var title: Text { Text("tip_check_title") }
+    var message: Text? { Text("tip_check_message") }
+    var options: [any TipOption] { [MaxDisplayCount(1)] }
+}
+
+/// Taught only after the user checks a gym activity for the first time — that's when
+/// "you can also log the weight" becomes relevant. Anchored to the row body, whose
+/// tap opens the session log.
+struct LogWeightTip: Tip {
+    static let didCheckGymActivity = Tips.Event(id: "didCheckGymActivity")
+
+    var title: Text { Text("tip_weight_title") }
+    var message: Text? { Text("tip_weight_message") }
+    var rules: [Rule] {
+        #Rule(Self.didCheckGymActivity) { $0.donations.count >= 1 }
+    }
+    var options: [any TipOption] { [MaxDisplayCount(1)] }
+}
+
+/// Shown inline above the list the first time a weekly reset actually clears checks —
+/// the exact moment the user sees their checkmarks disappear and needs the mental
+/// model ("the list starts fresh every Monday") explained.
+struct WeeklyResetTip: Tip {
+    static let didResetWeek = Tips.Event(id: "didResetWeek")
+
+    var title: Text { Text("tip_reset_title") }
+    var message: Text? { Text("tip_reset_message") }
+    var rules: [Rule] {
+        #Rule(Self.didResetWeek) { $0.donations.count >= 1 }
+    }
+    var options: [any TipOption] { [MaxDisplayCount(1)] }
+}

--- a/MuscleCheck/managers/UserDefaultsManager.swift
+++ b/MuscleCheck/managers/UserDefaultsManager.swift
@@ -27,6 +27,22 @@ final class UserDefaultsManager {
         set { defaults.set(newValue, forKey: "defaultEntriesCreated") }
     }
 
+    /// True once the user finished (or skipped) the first-run onboarding. The initial
+    /// seed is decided there, so `insertDefaultMuscleEntries` stays dormant until then.
+    var hasCompletedOnboarding: Bool {
+        get { defaults.bool(forKey: "hasCompletedOnboarding") }
+        set { defaults.set(newValue, forKey: "hasCompletedOnboarding") }
+    }
+
+    /// Users who predate onboarding already got the gym seed — they must never see the
+    /// welcome flow. Runs at app init, before the first body evaluation, so the
+    /// fullScreenCover never flashes for them.
+    func migrateOnboardingFlagIfNeeded() {
+        if defaultEntriesCreated && !hasCompletedOnboarding {
+            hasCompletedOnboarding = true
+        }
+    }
+
     // 0 = system, 1 = light, 2 = dark
     var appTheme: Int {
         get { defaults.integer(forKey: "appTheme") }

--- a/MuscleCheck/viewModels/ContentViewModel.swift
+++ b/MuscleCheck/viewModels/ContentViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftData
 import HealthKit
+import TipKit
 
 @MainActor
 final class ContentViewModel: ObservableObject {
@@ -117,7 +118,14 @@ final class ContentViewModel: ObservableObject {
     
     if currentWeek != UserDefaultsManager.shared.lastResetWeek ||
         currentYear != UserDefaultsManager.shared.lastResetYear {
-      
+
+      // Teach the weekly-reset model only when checks are actually being cleared —
+      // this also keeps the very first launch (lastResetWeek == 0, nothing checked)
+      // from counting as a "reset".
+      if entries.contains(where: { $0.isChecked }) {
+        Task { await WeeklyResetTip.didResetWeek.donate() }
+      }
+
       entries.forEach {
         $0.isChecked = false
         $0.weekOfYear = currentWeek
@@ -188,6 +196,10 @@ final class ContentViewModel: ObservableObject {
   
   func insertDefaultMuscleEntries() {
 
+    // The initial seed is chosen in onboarding now; this stays only as a safety net
+    // for the odd state "onboarded but never seeded" (e.g. pre-onboarding installs
+    // whose defaults survived a store wipe).
+    guard UserDefaultsManager.shared.hasCompletedOnboarding else { return }
     guard !UserDefaultsManager.shared.defaultEntriesCreated else { return }
     
     let defaultGroups = [
@@ -233,6 +245,13 @@ final class ContentViewModel: ObservableObject {
       entry.removeSession(matching: today)
     } else {
         entry.addSession(today)
+        // First-ever check completes the "how to check" lesson; checking a gym-style
+        // entry makes the weight-log tip eligible (built-ins only — custom categories
+        // opting into weight don't need the gym-worded tip).
+        CheckActivityTip().invalidate(reason: .actionPerformed)
+        if ActivityCategory(rawValue: entry.category)?.tracksWeight == true {
+          Task { await LogWeightTip.didCheckGymActivity.donate() }
+        }
     }
     entry.isChecked.toggle()
     do {

--- a/MuscleCheck/viewModels/OnboardingViewModel.swift
+++ b/MuscleCheck/viewModels/OnboardingViewModel.swift
@@ -1,0 +1,61 @@
+//
+//  OnboardingViewModel.swift
+//  MuscleCheck
+//
+//  First-run onboarding: the user picks their disciplines and the initial checklist
+//  is seeded from their presets (instead of the old always-gym seed).
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+final class OnboardingViewModel: ObservableObject {
+
+    /// Gym starts selected: it's the most common discipline and gives "Skip" and
+    /// "Continue" the same default outcome.
+    @Published var selectedCategories: Set<ActivityCategory> = [.gym]
+
+    /// Built-ins offered in the picker. `.custom` is a resolver fallback for orphaned
+    /// entries, not a discipline the user would choose.
+    let selectableCategories = ActivityCategory.allCases.filter { $0 != .custom }
+
+    var canContinue: Bool { !selectedCategories.isEmpty }
+
+    func toggle(_ category: ActivityCategory) {
+        if selectedCategories.contains(category) {
+            selectedCategories.remove(category)
+        } else {
+            selectedCategories.insert(category)
+        }
+    }
+
+    func completeOnboarding(context: ModelContextProtocol) {
+        seed(selectedCategories, context: context)
+    }
+
+    /// Skipping keeps parity with the pre-onboarding behavior: a gym checklist.
+    func skipOnboarding(context: ModelContextProtocol) {
+        seed([.gym], context: context)
+    }
+
+    private func seed(_ categories: Set<ActivityCategory>, context: ModelContextProtocol) {
+        let manager = MuscleEntryManager(context: context)
+        for category in categories.sorted(by: { $0.sortOrder < $1.sortOrder }) {
+            // One failed category must not block finishing onboarding — presets can
+            // be re-added any time from Settings → Activity Presets.
+            try? manager.addPresetEntries(for: category)
+        }
+
+        // Mirror what Settings does when adding presets, so those categories show
+        // their green check there.
+        var presets = Set(UserDefaultsManager.shared.addedActivityPresets)
+        presets.formUnion(categories.map(\.rawValue))
+        UserDefaultsManager.shared.addedActivityPresets = Array(presets)
+
+        // Both flags: completing onboarding IS the initial seed, and setting
+        // hasCompletedOnboarding dismisses the cover (ContentView observes the key).
+        UserDefaultsManager.shared.defaultEntriesCreated = true
+        UserDefaultsManager.shared.hasCompletedOnboarding = true
+    }
+}

--- a/MuscleCheckTests/ContentViewModelTests.swift
+++ b/MuscleCheckTests/ContentViewModelTests.swift
@@ -11,11 +11,15 @@ import Testing
 import SwiftData
 import Foundation
 
+// Serialized: these tests contend on shared UserDefaults flags (onboarding/seed state).
+@Suite(.serialized)
 struct ContentViewModelTests {
 
     @MainActor @Test
     func testInsertDefaultMuscleEntriesOnlyOnce() async {
         let context = MockContext()
+        // Fallback seed path: onboarded but never seeded.
+        UserDefaultsManager.shared.hasCompletedOnboarding = true
         UserDefaultsManager.shared.defaultEntriesCreated = false
 
         let viewModel = ContentViewModel()
@@ -23,6 +27,20 @@ struct ContentViewModelTests {
 
         #expect(context.inserted.count > 0)
         #expect(UserDefaultsManager.shared.defaultEntriesCreated == true)
+    }
+
+    @MainActor @Test
+    func testSeedSkippedWhileOnboardingPending() async {
+        let context = MockContext()
+        // New install: onboarding decides the seed, so setup must not insert anything.
+        UserDefaultsManager.shared.hasCompletedOnboarding = false
+        UserDefaultsManager.shared.defaultEntriesCreated = false
+
+        let viewModel = ContentViewModel()
+        await viewModel.setup(context: context, entries: [])
+
+        #expect(context.inserted.isEmpty)
+        #expect(UserDefaultsManager.shared.defaultEntriesCreated == false)
     }
 
     @MainActor @Test

--- a/MuscleCheckTests/OnboardingViewModelTests.swift
+++ b/MuscleCheckTests/OnboardingViewModelTests.swift
@@ -1,0 +1,97 @@
+//
+//  OnboardingViewModelTests.swift
+//  MuscleCheckTests
+//
+//  First-run onboarding: selection state, preset seeding and flag migration.
+//
+
+import Testing
+@testable import MuscleCheck
+import Foundation
+
+// Serialized: these tests contend on shared UserDefaults flags (onboarding/seed state).
+@Suite(.serialized)
+struct OnboardingViewModelTests {
+
+    @MainActor
+    private func resetFlags() {
+        UserDefaultsManager.shared.hasCompletedOnboarding = false
+        UserDefaultsManager.shared.defaultEntriesCreated = false
+        UserDefaultsManager.shared.addedActivityPresets = []
+    }
+
+    @MainActor @Test
+    func gymStartsSelectedAndCustomIsNotOffered() {
+        let viewModel = OnboardingViewModel()
+
+        #expect(viewModel.selectedCategories == [.gym])
+        #expect(viewModel.canContinue)
+        #expect(!viewModel.selectableCategories.contains(.custom))
+    }
+
+    @MainActor @Test
+    func emptySelectionDisablesContinue() {
+        let viewModel = OnboardingViewModel()
+
+        viewModel.toggle(.gym)
+
+        #expect(viewModel.selectedCategories.isEmpty)
+        #expect(!viewModel.canContinue)
+    }
+
+    @MainActor @Test
+    func completingSeedsPresetsForSelectedCategories() {
+        resetFlags()
+        let context = MockContext()
+        let viewModel = OnboardingViewModel()
+
+        viewModel.toggle(.yoga) // gym stays pre-selected → gym + yoga
+        viewModel.completeOnboarding(context: context)
+
+        let expected = ActivityCategory.gym.presetEntries.count + ActivityCategory.yoga.presetEntries.count
+        #expect(context.inserted.count == expected)
+        #expect(context.inserted.contains { $0.category == ActivityCategory.gym.rawValue })
+        #expect(context.inserted.contains { $0.category == ActivityCategory.yoga.rawValue })
+        #expect(context.saved)
+
+        #expect(UserDefaultsManager.shared.hasCompletedOnboarding)
+        #expect(UserDefaultsManager.shared.defaultEntriesCreated)
+        #expect(Set(UserDefaultsManager.shared.addedActivityPresets)
+            .isSuperset(of: [ActivityCategory.gym.rawValue, ActivityCategory.yoga.rawValue]))
+    }
+
+    @MainActor @Test
+    func skipSeedsGymPresetsOnly() {
+        resetFlags()
+        let context = MockContext()
+        let viewModel = OnboardingViewModel()
+
+        viewModel.toggle(.yoga) // selection is ignored on skip
+        viewModel.skipOnboarding(context: context)
+
+        #expect(context.inserted.count == ActivityCategory.gym.presetEntries.count)
+        #expect(context.inserted.allSatisfy { $0.category == ActivityCategory.gym.rawValue })
+        #expect(UserDefaultsManager.shared.hasCompletedOnboarding)
+        #expect(UserDefaultsManager.shared.defaultEntriesCreated)
+    }
+
+    @MainActor @Test
+    func migrationMarksExistingUsersAsOnboarded() {
+        UserDefaultsManager.shared.defaultEntriesCreated = true
+        UserDefaultsManager.shared.hasCompletedOnboarding = false
+
+        UserDefaultsManager.shared.migrateOnboardingFlagIfNeeded()
+
+        #expect(UserDefaultsManager.shared.hasCompletedOnboarding)
+    }
+
+    @MainActor @Test
+    func migrationLeavesNewInstallsPendingOnboarding() {
+        UserDefaultsManager.shared.defaultEntriesCreated = false
+        UserDefaultsManager.shared.hasCompletedOnboarding = false
+
+        UserDefaultsManager.shared.migrateOnboardingFlagIfNeeded()
+
+        #expect(!UserDefaultsManager.shared.hasCompletedOnboarding)
+    }
+}

--- a/MuscleCheckUITests/OnboardingUITests.swift
+++ b/MuscleCheckUITests/OnboardingUITests.swift
@@ -1,0 +1,97 @@
+//
+//  OnboardingUITests.swift
+//  MuscleCheckUITests
+//
+//  Drives the first-run onboarding end-to-end: welcome → category picker →
+//  personalized seed → first contextual tip on the home list.
+//
+
+import XCTest
+
+final class OnboardingUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private func makeApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        // -resetOnboarding forces the first-run state on an installed build. Tips stay
+        // ENABLED here (no -uiTesting): this flow asserts the first tip shows up.
+        app.launchArguments += [
+            "-AppleLanguages", "(en)", "-AppleLocale", "en_US",
+            "-resetOnboarding", "YES"
+        ]
+        return app
+    }
+
+    /// Welcome → picker. Retries the CTA tap once: a tap can land while the cover is
+    /// still animating in and get swallowed.
+    private func advanceToPicker(_ app: XCUIApplication) {
+        let start = app.buttons["onboarding.start"]
+        XCTAssertTrue(start.waitForExistence(timeout: 10), "Welcome screen not shown on first run")
+        start.tap()
+        let skip = app.buttons["onboarding.skip"]
+        if !skip.waitForExistence(timeout: 5) {
+            start.tap()
+            XCTAssertTrue(skip.waitForExistence(timeout: 5), "Category picker not shown after tapping Get Started")
+        }
+    }
+
+    @MainActor
+    func testOnboardingSeedsSelectedCategoriesAndShowsCheckTip() throws {
+        let app = makeApp()
+        app.launch()
+
+        attachScreenshot(app, name: "01-welcome")
+        advanceToPicker(app)
+
+        // Picker: gym is pre-selected; add yoga, then create the list.
+        XCTAssertTrue(app.buttons["onboarding.category.gym"].isSelected, "Gym should start selected")
+        app.buttons["onboarding.category.yoga"].tap()
+        attachScreenshot(app, name: "02-picker-gym-yoga")
+        app.buttons["onboarding.createList"].tap()
+
+        // Home list seeded: gym presets visible at the top.
+        let chestRow = app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "Chest")).firstMatch
+        XCTAssertTrue(chestRow.waitForExistence(timeout: 10), "Gym presets not seeded after onboarding")
+
+        // The "check" tip pops on the first row — the first contextual lesson.
+        let checkTip = app.staticTexts["Trained today?"]
+        XCTAssertTrue(checkTip.waitForExistence(timeout: 10), "Check tip not shown after onboarding")
+        attachScreenshot(app, name: "03-home-seeded-with-tip")
+
+        // Dismiss the tip popover so it can't swallow the scroll gesture.
+        let closeTip = app.buttons["Close"].firstMatch
+        if closeTip.waitForExistence(timeout: 2) { closeTip.tap() }
+
+        // Yoga section is below the fold of a lazy List — scroll it into existence.
+        let yogaRow = app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "Vinyasa")).firstMatch
+        for _ in 0..<3 where !yogaRow.exists { app.swipeUp() }
+        XCTAssertTrue(yogaRow.waitForExistence(timeout: 5), "Yoga presets not seeded after onboarding")
+        attachScreenshot(app, name: "04-yoga-section-seeded")
+    }
+
+    @MainActor
+    func testSkipLandsOnChecklist() throws {
+        let app = makeApp()
+        app.launch()
+
+        advanceToPicker(app)
+        app.buttons["onboarding.skip"].tap()
+
+        // Skip completes onboarding and lands on a seeded checklist. (Gym-ONLY seeding
+        // is asserted in unit tests — the sim's store may carry entries from other runs.)
+        let chestRow = app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "Chest")).firstMatch
+        XCTAssertTrue(chestRow.waitForExistence(timeout: 10), "Checklist not shown after skipping onboarding")
+        XCTAssertFalse(app.buttons["onboarding.skip"].exists, "Onboarding still on screen after skip")
+        attachScreenshot(app, name: "05-skip-lands-on-checklist")
+    }
+
+    private func attachScreenshot(_ app: XCUIApplication, name: String) {
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = name
+        shot.lifetime = .keepAlways
+        add(shot)
+    }
+}

--- a/MuscleCheckUITests/SessionLogUITests.swift
+++ b/MuscleCheckUITests/SessionLogUITests.swift
@@ -15,8 +15,13 @@ final class SessionLogUITests: XCTestCase {
 
     private func makeApp() -> XCUIApplication {
         let app = XCUIApplication()
-        // Force English + kg so the assertions are deterministic.
-        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        // Force English + kg so the assertions are deterministic. Skip onboarding
+        // (arguments domain wins over the persisted flag) so the gym seed still
+        // happens on a fresh simulator, and disable tips so no popover covers rows.
+        app.launchArguments += [
+            "-AppleLanguages", "(en)", "-AppleLocale", "en_US",
+            "-hasCompletedOnboarding", "YES", "-uiTesting", "YES"
+        ]
         return app
     }
 
@@ -94,8 +99,11 @@ final class SessionLogUITests: XCTestCase {
         yogaOption.tap()
         app.navigationBars.buttons["Save"].tap()
 
-        // Tap the new yoga row — the modal must NOT open (gym-only guard).
+        // Tap the new yoga row — the modal must NOT open (gym-only guard). The row can
+        // land below the fold of the lazy List (other suites may have seeded more
+        // entries on this simulator), so scroll it into existence first.
         let yogaRow = app.staticTexts[yogaName]
+        for _ in 0..<4 where !yogaRow.exists { app.swipeUp() }
         XCTAssertTrue(yogaRow.waitForExistence(timeout: 5), "Yoga row was not created")
         yogaRow.tap()
         XCTAssertFalse(app.navigationBars["Log"].waitForExistence(timeout: 2),

--- a/MuscleCheckUITests/ToolbarUITests.swift
+++ b/MuscleCheckUITests/ToolbarUITests.swift
@@ -17,6 +17,8 @@ final class ToolbarUITests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments += [
             "-AppleLanguages", "(en)", "-AppleLocale", "en_US",
+            // Skip onboarding and disable tips — this test drives the home toolbar.
+            "-hasCompletedOnboarding", "YES", "-uiTesting", "YES",
             // Force the largest accessibility text size to provoke toolbar overflow.
             "-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibilityExtraExtraExtraLarge"
         ]

--- a/docs/android-plan.md
+++ b/docs/android-plan.md
@@ -1,0 +1,61 @@
+# MuscleCheck Android — Plan de migración
+
+**Decisión:** rewrite nativo en Kotlin + Jetpack Compose (opción elegida sobre KMP y Skip).
+Repo separado: `~/Desktop/sideProjects/musclecheck-android`. Package `com.zadkiel.musclecheck`
+(mismo que el bundle ID iOS → mismo proyecto RevenueCat y Firebase).
+
+## Mapeo de stack
+
+| iOS | Android |
+|---|---|
+| SwiftUI | Jetpack Compose (Material 3) |
+| SwiftData | Room (entities + DAOs con Flow) |
+| UserDefaults / App Group | DataStore Preferences |
+| WidgetKit | Glance |
+| ObservableObject + @Published | ViewModel + StateFlow |
+| Manager + protocolo + .shared | Repository + interface + Hilt |
+| Swift Charts | Charts hand-rolled en Compose (2 charts simples, sin dependencia) |
+| UNUserNotificationCenter | WorkManager + POST_NOTIFICATIONS |
+| RevenueCat iOS | RevenueCat Android (purchases-android) |
+| HealthKit | Health Connect (**diferido a v2**) |
+| FoundationModels (AI Coach) | **Sin equivalente — diferido** (Gemini Nano no cubre toda la base) |
+| AppIntents / Siri | Diferido |
+| Localizable.xcstrings | strings.xml ES/EN/FR/IT |
+
+## Decisiones técnicas
+
+- **minSdk 26, target/compile 35.** Single module.
+- **Semántica de semana:** `WeekFields(MONDAY, minimalDays=1)` — NO `WeekFields.ISO`
+  (Apple usa `minimumDaysInFirstWeek = 1`; ISO usa 4 y numeraría distinto algunas semanas de borde de año).
+- **Íconos:** la DB guarda los mismos IDs de SF Symbols que iOS (`figure.yoga`, …) para
+  portabilidad de datos; la UI los mapea a Material Symbols. Ícono desconocido → fallback estrella.
+- **Pesos siempre en kg** en storage; conversión kg/lbs en el borde de display (igual que iOS).
+- **Sessions:** tabla propia con FK a entry (relacional idiomático), no JSON embebido como SwiftData.
+- **Tests del dominio portados de las suites Swift** — son la spec de las semánticas finas
+  (racha semanal con gracia, degradación de categoría huérfana, grid 6×7 lunes-first).
+
+## Fases
+
+1. ✅ Toolchain (JDK 21 brew, Android cmdline-tools, platform 35)
+2. ✅ Scaffold Gradle + dominio puro con tests (JVM)
+3. ✅ Data layer: Room + DataStore + repositories
+4. ✅ UI core loop: checklist semanal + add group + modal de peso
+5. ✅ Historial + stats + streak card
+6. ✅ Settings (units, theme, custom categories, presets) + onboarding
+7. Notificaciones (WorkManager) ✅ · widget Glance ✅ · progress photos (pendiente)
+   - Notificaciones: `InactivityCalculator` (dominio puro, 11 tests portados de la suite iOS),
+     `ReminderScheduler` (periodic daily + one-shot inactividad mañana 10:00, re-encolado
+     al ir a background vía ProcessLifecycleOwner), workers con @HiltWorker, toggle + time
+     picker en Settings con permiso POST_NOTIFICATIONS (API 33+). El resumen de inactividad
+     se computa al momento de disparar (no al agendar, como iOS) → nunca queda stale.
+   - Widget: Glance 2×2 con racha (🔥 actual / 🏆 máx) + checklist de la semana (hasta 5).
+     Lee Room directo vía Hilt EntryPoint (sin App Group). `MuscleRepository` refresca el
+     widget tras cada mutación (espejo del reloadTimelines de iOS). Sin íconos por actividad
+     en v1 (Glance no renderiza ImageVectors; evaluar drawables por categoría).
+8. RevenueCat + paywall, localización FR/IT, build final
+
+## Blockers externos (requieren acción del developer)
+
+- **Play Console:** cuenta (USD 25) + closed test de 14 días con ~12 testers antes de producción.
+- **Firebase:** agregar app Android al proyecto existente → `google-services.json` (el código queda listo con Analytics/Crashlytics opcionales hasta tenerlo).
+- **RevenueCat:** agregar app Android al proyecto + API key pública Android + productos en Play Billing.


### PR DESCRIPTION
## Summary
- Two-screen first-run onboarding: welcome cover + discipline picker; the initial checklist is seeded from the selected presets (skip = gym, parity with the old seed)
- Pre-onboarding installs are migrated at app init (`migrateOnboardingFlagIfNeeded`) so existing users never see the welcome flow
- Progressive disclosure via TipKit, each tip shows once: check circle (first row), weight logging (after first gym check), weekly reset (first time checks actually clear)
- UI test suites skip onboarding and disable tips via launch arguments; new `OnboardingViewModelTests` + `OnboardingUITests`
- Also adds `docs/android-plan.md` (Android port plan + phase status)

## Test plan
- [x] Unit tests green on iPhone 16 sim (`MuscleCheckTests`)
- [x] UI suites updated with onboarding-skip launch args

🤖 Generated with [Claude Code](https://claude.com/claude-code)