### PR TITLE
feat(android): Pro entitlement seam + paywall + progress-photos gate

### DIFF
--- a/android/app/src/main/java/com/zadkiel/musclecheck/data/prefs/UserPreferencesRepository.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/data/prefs/UserPreferencesRepository.kt
@@ -37,7 +37,12 @@ class UserPreferencesRepository @Inject constructor(
         val notificationsEnabled = booleanPreferencesKey("notificationsEnabled")
         val reminderHour = intPreferencesKey("reminderHour")
         val reminderMinute = intPreferencesKey("reminderMinute")
+        val isPro = booleanPreferencesKey("isPro")
     }
+
+    /** Local Pro entitlement flag. Source of truth for [com.zadkiel.musclecheck.data.pro.LocalProAccessManager]. */
+    val isPro: Flow<Boolean> =
+        context.dataStore.data.map { it[Keys.isPro] ?: false }
 
     val hasCompletedOnboarding: Flow<Boolean> =
         context.dataStore.data.map { it[Keys.hasCompletedOnboarding] ?: false }
@@ -81,6 +86,10 @@ class UserPreferencesRepository @Inject constructor(
 
     suspend fun setNotificationsEnabled(value: Boolean) {
         context.dataStore.edit { it[Keys.notificationsEnabled] = value }
+    }
+
+    suspend fun setPro(value: Boolean) {
+        context.dataStore.edit { it[Keys.isPro] = value }
     }
 
     suspend fun setReminderTime(hour: Int, minute: Int) {

--- a/android/app/src/main/java/com/zadkiel/musclecheck/data/pro/LocalProAccessManager.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/data/pro/LocalProAccessManager.kt
@@ -1,0 +1,46 @@
+package com.zadkiel.musclecheck.data.pro
+
+import com.zadkiel.musclecheck.data.prefs.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Local, DataStore-backed entitlement — the port's stand-in until RevenueCat is
+ * wired. RevenueCat is blocked on external Play Console setup (paid developer
+ * account, Play Billing products, and an Android public API key), so this keeps
+ * the gate and paywall fully exercisable in the meantime: [purchase] grants the
+ * entitlement locally instead of hitting the store.
+ *
+ * RevenueCat swap point — replace this class's body with the SDK calls; nothing
+ * outside this file changes:
+ *   - configure `Purchases` with the Android API key at app start;
+ *   - `isPro`   ← `customerInfo.entitlements["pro"]?.isActive == true`;
+ *   - `purchase`← `Purchases.sharedInstance.awaitPurchase(pkg.toRevenueCatPackage())`;
+ *   - `restore` ← `Purchases.sharedInstance.awaitRestore()`.
+ */
+@Singleton
+class LocalProAccessManager @Inject constructor(
+    private val prefs: UserPreferencesRepository,
+) : ProAccessManager {
+
+    override val isPro: Flow<Boolean> = prefs.isPro
+
+    private val _isLoading = MutableStateFlow(false)
+    override val isLoading: Flow<Boolean> = _isLoading.asStateFlow()
+
+    override suspend fun purchase(pkg: ProPackage) {
+        _isLoading.value = true
+        try {
+            prefs.setPro(true)
+        } finally {
+            _isLoading.value = false
+        }
+    }
+
+    override suspend fun restore() {
+        // No remote receipts in the local stub — restore keeps whatever is stored.
+    }
+}

--- a/android/app/src/main/java/com/zadkiel/musclecheck/data/pro/ProAccessManager.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/data/pro/ProAccessManager.kt
@@ -1,0 +1,29 @@
+package com.zadkiel.musclecheck.data.pro
+
+import kotlinx.coroutines.flow.Flow
+
+/** The three purchasable tiers — mirrors the iOS `PackageType`. */
+enum class ProPackage { MONTHLY, YEARLY, LIFETIME }
+
+/**
+ * Source of truth for the user's Pro entitlement and the purchase flow.
+ *
+ * The rest of the app talks only to this interface (the Android mirror of the
+ * iOS `StoreManagerProtocol` seam), so wiring the real RevenueCat SDK later is a
+ * single-implementation swap — see [LocalProAccessManager] for the swap point.
+ */
+interface ProAccessManager {
+    /** Whether the current user has an active Pro entitlement. */
+    val isPro: Flow<Boolean>
+
+    /** True while a purchase or restore is in flight. */
+    val isLoading: Flow<Boolean>
+
+    /** Buys [pkg]; grants the entitlement on success, throws [ProPurchaseException] on failure. */
+    suspend fun purchase(pkg: ProPackage)
+
+    /** Re-applies a previously-bought entitlement. */
+    suspend fun restore()
+}
+
+class ProPurchaseException(message: String) : Exception(message)

--- a/android/app/src/main/java/com/zadkiel/musclecheck/di/AppModule.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/di/AppModule.kt
@@ -6,6 +6,8 @@ import com.zadkiel.musclecheck.data.local.AppDatabase
 import com.zadkiel.musclecheck.data.local.CategoryDao
 import com.zadkiel.musclecheck.data.local.MuscleDao
 import com.zadkiel.musclecheck.data.local.ProgressPhotoDao
+import com.zadkiel.musclecheck.data.pro.LocalProAccessManager
+import com.zadkiel.musclecheck.data.pro.ProAccessManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,4 +36,9 @@ object AppModule {
 
     @Provides
     fun provideProgressPhotoDao(db: AppDatabase): ProgressPhotoDao = db.progressPhotoDao()
+
+    // Swap LocalProAccessManager for a RevenueCat-backed impl once billing is set up.
+    @Provides
+    @Singleton
+    fun provideProAccessManager(impl: LocalProAccessManager): ProAccessManager = impl
 }

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/navigation/MuscleCheckApp.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/navigation/MuscleCheckApp.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.rememberNavController
 import com.zadkiel.musclecheck.ui.history.HistoryScreen
 import com.zadkiel.musclecheck.ui.home.HomeScreen
 import com.zadkiel.musclecheck.ui.onboarding.OnboardingScreen
+import com.zadkiel.musclecheck.ui.pro.PaywallScreen
 import com.zadkiel.musclecheck.ui.progress.ProgressPhotosScreen
 import com.zadkiel.musclecheck.ui.settings.ManageCategoriesScreen
 import com.zadkiel.musclecheck.ui.settings.SettingsScreen
@@ -19,6 +20,7 @@ object Routes {
     const val SETTINGS = "settings"
     const val CATEGORIES = "categories"
     const val PROGRESS = "progress"
+    const val PAYWALL = "paywall"
 }
 
 @Composable
@@ -39,7 +41,13 @@ fun MuscleCheckApp(hasCompletedOnboarding: Boolean) {
             )
         }
         composable(Routes.PROGRESS) {
-            ProgressPhotosScreen(onBack = { navController.popBackStack() })
+            ProgressPhotosScreen(
+                onBack = { navController.popBackStack() },
+                onUpgrade = { navController.navigate(Routes.PAYWALL) },
+            )
+        }
+        composable(Routes.PAYWALL) {
+            PaywallScreen(onClose = { navController.popBackStack() })
         }
         composable(Routes.HISTORY) {
             HistoryScreen(onBack = { navController.popBackStack() })
@@ -51,6 +59,7 @@ fun MuscleCheckApp(hasCompletedOnboarding: Boolean) {
             SettingsScreen(
                 onBack = { navController.popBackStack() },
                 onOpenCategories = { navController.navigate(Routes.CATEGORIES) },
+                onOpenPaywall = { navController.navigate(Routes.PAYWALL) },
             )
         }
         composable(Routes.CATEGORIES) {

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/pro/PaywallScreen.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/pro/PaywallScreen.kt
@@ -1,0 +1,272 @@
+package com.zadkiel.musclecheck.ui.pro
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.WorkspacePremium
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.Button
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zadkiel.musclecheck.R
+import com.zadkiel.musclecheck.data.pro.ProPackage
+
+/** A Free-vs-Pro feature row. */
+private data class CompareRow(val labelRes: Int, val free: Boolean)
+
+// Reflects what the app actually gates today: checklist, AI coach, history,
+// stats and notifications ship free; only progress photos are Pro.
+private val compareRows = listOf(
+    CompareRow(R.string.paywall_compare_checklist, free = true),
+    CompareRow(R.string.paywall_compare_ai, free = true),
+    CompareRow(R.string.paywall_compare_history, free = true),
+    CompareRow(R.string.paywall_compare_stats, free = true),
+    CompareRow(R.string.paywall_compare_notifications, free = true),
+    CompareRow(R.string.paywall_compare_photos, free = false),
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PaywallScreen(
+    onClose: () -> Unit,
+    viewModel: PaywallViewModel = hiltViewModel(),
+) {
+    val isPro by viewModel.isPro.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val selected by viewModel.selectedPackage.collectAsStateWithLifecycle()
+
+    // Close as soon as the entitlement is granted (mirrors iOS dismiss-on-success).
+    LaunchedEffect(isPro) {
+        if (isPro) onClose()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {},
+                actions = {
+                    IconButton(onClick = onClose) {
+                        Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.action_close))
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Spacer(Modifier.height(8.dp))
+            Icon(
+                Icons.Filled.WorkspacePremium,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(52.dp),
+            )
+            Text(
+                text = stringResource(R.string.paywall_title),
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(R.string.paywall_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+
+            ComparisonTable()
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                PackageOption(
+                    title = stringResource(R.string.paywall_yearly),
+                    price = stringResource(R.string.paywall_price_yearly),
+                    badge = stringResource(R.string.paywall_best_value),
+                    selected = selected == ProPackage.YEARLY,
+                    onClick = { viewModel.select(ProPackage.YEARLY) },
+                )
+                PackageOption(
+                    title = stringResource(R.string.paywall_monthly),
+                    price = stringResource(R.string.paywall_price_monthly),
+                    badge = null,
+                    selected = selected == ProPackage.MONTHLY,
+                    onClick = { viewModel.select(ProPackage.MONTHLY) },
+                )
+                PackageOption(
+                    title = stringResource(R.string.paywall_lifetime),
+                    price = stringResource(R.string.paywall_price_lifetime),
+                    badge = stringResource(R.string.paywall_one_time),
+                    selected = selected == ProPackage.LIFETIME,
+                    onClick = { viewModel.select(ProPackage.LIFETIME) },
+                )
+            }
+
+            Button(
+                onClick = viewModel::purchase,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(22.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text(stringResource(R.string.paywall_subscribe), fontWeight = FontWeight.SemiBold)
+                }
+            }
+
+            TextButton(onClick = viewModel::restore, enabled = !isLoading) {
+                Text(
+                    stringResource(R.string.paywall_restore),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+    }
+}
+
+@Composable
+private fun ComparisonTable() {
+    Column(Modifier.fillMaxWidth()) {
+        Row(Modifier.fillMaxWidth().padding(bottom = 4.dp)) {
+            Spacer(Modifier.weight(1f))
+            Text(
+                stringResource(R.string.paywall_compare_free),
+                modifier = Modifier.width(56.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                stringResource(R.string.paywall_compare_pro),
+                modifier = Modifier.width(56.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        compareRows.forEachIndexed { index, row ->
+            Row(
+                Modifier.fillMaxWidth().padding(vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    stringResource(row.labelRes),
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                CompareCell(on = row.free, accent = false, modifier = Modifier.width(56.dp))
+                CompareCell(on = true, accent = true, modifier = Modifier.width(56.dp))
+            }
+            if (index < compareRows.lastIndex) HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun CompareCell(on: Boolean, accent: Boolean, modifier: Modifier = Modifier) {
+    val color = when {
+        !on -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+        accent -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Box(modifier, contentAlignment = Alignment.Center) {
+        Icon(
+            if (on) Icons.Filled.Check else Icons.Filled.Remove,
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}
+
+@Composable
+private fun PackageOption(
+    title: String,
+    price: String,
+    badge: String?,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val borderColor =
+        if (selected) MaterialTheme.colorScheme.primary
+        else MaterialTheme.colorScheme.outline.copy(alpha = 0.4f)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(if (selected) 2.dp else 1.dp, borderColor, RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(title, style = MaterialTheme.typography.titleMedium)
+        badge?.let {
+            Spacer(Modifier.width(8.dp))
+            Box(
+                Modifier
+                    .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(4.dp))
+                    .padding(horizontal = 6.dp, vertical = 2.dp),
+            ) {
+                Text(
+                    it,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+        Spacer(Modifier.weight(1f))
+        Text(price, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+    }
+}

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/pro/PaywallViewModel.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/pro/PaywallViewModel.kt
@@ -1,0 +1,61 @@
+package com.zadkiel.musclecheck.ui.pro
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zadkiel.musclecheck.data.pro.ProAccessManager
+import com.zadkiel.musclecheck.data.pro.ProPackage
+import com.zadkiel.musclecheck.data.pro.ProPurchaseException
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PaywallViewModel @Inject constructor(
+    private val proAccess: ProAccessManager,
+) : ViewModel() {
+
+    val isPro: StateFlow<Boolean> =
+        proAccess.isPro.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val isLoading: StateFlow<Boolean> =
+        proAccess.isLoading.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    private val _selectedPackage = MutableStateFlow(ProPackage.YEARLY)
+    val selectedPackage: StateFlow<ProPackage> = _selectedPackage.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun select(pkg: ProPackage) {
+        _selectedPackage.value = pkg
+    }
+
+    fun purchase() {
+        viewModelScope.launch {
+            try {
+                proAccess.purchase(_selectedPackage.value)
+            } catch (e: ProPurchaseException) {
+                _error.value = e.message
+            }
+        }
+    }
+
+    fun restore() {
+        viewModelScope.launch {
+            try {
+                proAccess.restore()
+            } catch (e: ProPurchaseException) {
+                _error.value = e.message
+            }
+        }
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+}

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/pro/ProLockedCard.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/pro/ProLockedCard.kt
@@ -1,0 +1,72 @@
+package com.zadkiel.musclecheck.ui.pro
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.WorkspacePremium
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import com.zadkiel.musclecheck.R
+
+/** Full-screen Pro upsell shown in place of a gated feature (mirrors iOS ProFeatureGate `.card`). */
+@Composable
+fun ProLockedCard(
+    title: String,
+    description: String,
+    onUpgrade: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Card(
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            Column(
+                modifier = Modifier.padding(28.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Icon(
+                    Icons.Filled.WorkspacePremium,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(44.dp),
+                )
+                Text(
+                    title,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+                Button(onClick = onUpgrade) {
+                    Text(stringResource(R.string.pro_unlock_button), fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/progress/ProgressPhotosScreen.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/progress/ProgressPhotosScreen.kt
@@ -61,6 +61,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.zadkiel.musclecheck.R
 import com.zadkiel.musclecheck.domain.model.ProgressPhoto
+import com.zadkiel.musclecheck.ui.pro.ProLockedCard
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -70,9 +71,11 @@ import kotlin.math.roundToInt
 @Composable
 fun ProgressPhotosScreen(
     onBack: () -> Unit,
+    onUpgrade: () -> Unit,
     viewModel: ProgressPhotosViewModel = hiltViewModel(),
 ) {
     val photos by viewModel.photos.collectAsStateWithLifecycle()
+    val isPro by viewModel.isPro.collectAsStateWithLifecycle()
     var viewing by remember { mutableStateOf<ProgressPhoto?>(null) }
     var comparing by remember { mutableStateOf(false) }
 
@@ -90,7 +93,7 @@ fun ProgressPhotosScreen(
                     }
                 },
                 actions = {
-                    if (photos.size >= 2) {
+                    if (isPro && photos.size >= 2) {
                         IconButton(onClick = { comparing = true }) {
                             Icon(Icons.Filled.Compare, contentDescription = stringResource(R.string.progress_compare))
                         }
@@ -99,14 +102,23 @@ fun ProgressPhotosScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = {
-                picker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-            }) {
-                Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.progress_add_photo))
+            if (isPro) {
+                FloatingActionButton(onClick = {
+                    picker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                }) {
+                    Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.progress_add_photo))
+                }
             }
         },
     ) { padding ->
-        if (photos.isEmpty()) {
+        if (!isPro) {
+            ProLockedCard(
+                title = stringResource(R.string.progress_photos_title),
+                description = stringResource(R.string.progress_locked_description),
+                onUpgrade = onUpgrade,
+                modifier = Modifier.padding(padding),
+            )
+        } else if (photos.isEmpty()) {
             Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
                 Text(
                     stringResource(R.string.progress_empty),

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/progress/ProgressPhotosViewModel.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/progress/ProgressPhotosViewModel.kt
@@ -3,6 +3,7 @@ package com.zadkiel.musclecheck.ui.progress
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zadkiel.musclecheck.data.pro.ProAccessManager
 import com.zadkiel.musclecheck.data.repository.ProgressPhotoRepository
 import com.zadkiel.musclecheck.domain.model.ProgressPhoto
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,10 +17,14 @@ import javax.inject.Inject
 @HiltViewModel
 class ProgressPhotosViewModel @Inject constructor(
     private val repository: ProgressPhotoRepository,
+    proAccess: ProAccessManager,
 ) : ViewModel() {
 
     val photos: StateFlow<List<ProgressPhoto>> = repository.photos
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val isPro: StateFlow<Boolean> = proAccess.isPro
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     fun file(photo: ProgressPhoto): File = repository.file(photo)
 

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/settings/SettingsScreen.kt
@@ -25,10 +25,12 @@ import androidx.compose.material.icons.filled.AddCircleOutline
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.CreateNewFolder
+import androidx.compose.material.icons.filled.WorkspacePremium
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -59,6 +61,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zadkiel.musclecheck.BuildConfig
 import com.zadkiel.musclecheck.R
 import com.zadkiel.musclecheck.data.prefs.UserPreferencesRepository
+import com.zadkiel.musclecheck.data.pro.ProAccessManager
 import com.zadkiel.musclecheck.data.repository.MuscleRepository
 import com.zadkiel.musclecheck.domain.model.ActivityCategory
 import com.zadkiel.musclecheck.domain.model.WeightUnit
@@ -90,7 +93,15 @@ class SettingsViewModel @Inject constructor(
     private val prefs: UserPreferencesRepository,
     private val repository: MuscleRepository,
     private val reminderScheduler: ReminderScheduler,
+    private val proAccess: ProAccessManager,
 ) : ViewModel() {
+
+    val isPro: StateFlow<Boolean> = proAccess.isPro
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    fun restorePurchases() {
+        viewModelScope.launch { proAccess.restore() }
+    }
 
     val uiState: StateFlow<SettingsUiState> = combine(
         prefs.appTheme,
@@ -148,9 +159,11 @@ class SettingsViewModel @Inject constructor(
 fun SettingsScreen(
     onBack: () -> Unit,
     onOpenCategories: () -> Unit,
+    onOpenPaywall: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val isPro by viewModel.isPro.collectAsStateWithLifecycle()
     val accents = LocalAccents.current
 
     Scaffold(
@@ -173,6 +186,39 @@ fun SettingsScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {
+            // Subscription
+            SettingsSection(title = stringResource(R.string.settings_section_subscription)) {
+                if (isPro) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Filled.WorkspacePremium,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            stringResource(R.string.settings_pro_active),
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                    TextButton(onClick = viewModel::restorePurchases) {
+                        Text(stringResource(R.string.settings_restore_purchases))
+                    }
+                } else {
+                    Button(
+                        onClick = onOpenPaywall,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(Icons.Filled.WorkspacePremium, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.settings_upgrade_to_pro))
+                    }
+                    TextButton(onClick = viewModel::restorePurchases) {
+                        Text(stringResource(R.string.settings_restore_purchases))
+                    }
+                }
+            }
+
             // Appearance
             SettingsSection(title = stringResource(R.string.settings_section_appearance)) {
                 var themeMenuExpanded by remember { mutableStateOf(false) }

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -144,4 +144,33 @@
     <string name="progress_empty">Todavía no hay fotos. Tocá + para agregar tu primera foto de progreso.</string>
     <string name="progress_compare">Comparar</string>
     <string name="progress_delete">Eliminar foto</string>
+
+    <!-- Pro / paywall -->
+    <string name="action_close">Cerrar</string>
+    <string name="settings_section_subscription">Suscripción</string>
+    <string name="settings_upgrade_to_pro">Pasar a Pro</string>
+    <string name="settings_restore_purchases">Restaurar compras</string>
+    <string name="settings_pro_active">Pro activo</string>
+    <string name="pro_unlock_button">Desbloquear Pro</string>
+    <string name="progress_locked_description">Seguí tu transformación con fotos mensuales y un slider antes/después. Disponible con Pro.</string>
+    <string name="paywall_title">MuscleCheck Pro</string>
+    <string name="paywall_subtitle">Desbloqueá las fotos de progreso y apoyá la app.</string>
+    <string name="paywall_compare_free">Gratis</string>
+    <string name="paywall_compare_pro">Pro</string>
+    <string name="paywall_compare_checklist">Checklist semanal</string>
+    <string name="paywall_compare_ai">Coach IA</string>
+    <string name="paywall_compare_history">Historial y calendario</string>
+    <string name="paywall_compare_stats">Estadísticas</string>
+    <string name="paywall_compare_notifications">Recordatorios</string>
+    <string name="paywall_compare_photos">Fotos de progreso</string>
+    <string name="paywall_yearly">Anual</string>
+    <string name="paywall_monthly">Mensual</string>
+    <string name="paywall_lifetime">De por vida</string>
+    <string name="paywall_best_value">MEJOR VALOR</string>
+    <string name="paywall_one_time">PAGO ÚNICO</string>
+    <string name="paywall_price_yearly">$14.99</string>
+    <string name="paywall_price_monthly">$1.99</string>
+    <string name="paywall_price_lifetime">$29.99</string>
+    <string name="paywall_subscribe">Continuar</string>
+    <string name="paywall_restore">Restaurar compras</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -116,4 +116,33 @@
     <string name="progress_empty">Aucune photo. Touche + pour ajouter ta première photo de progression.</string>
     <string name="progress_compare">Comparer</string>
     <string name="progress_delete">Supprimer la photo</string>
+
+    <!-- Pro / paywall -->
+    <string name="action_close">Fermer</string>
+    <string name="settings_section_subscription">Abonnement</string>
+    <string name="settings_upgrade_to_pro">Passer à Pro</string>
+    <string name="settings_restore_purchases">Restaurer les achats</string>
+    <string name="settings_pro_active">Pro actif</string>
+    <string name="pro_unlock_button">Débloquer Pro</string>
+    <string name="progress_locked_description">Suivez votre transformation avec des photos mensuelles et un curseur avant/après. Disponible avec Pro.</string>
+    <string name="paywall_title">MuscleCheck Pro</string>
+    <string name="paywall_subtitle">Débloquez les photos de progression et soutenez l\'app.</string>
+    <string name="paywall_compare_free">Gratuit</string>
+    <string name="paywall_compare_pro">Pro</string>
+    <string name="paywall_compare_checklist">Check-list hebdo</string>
+    <string name="paywall_compare_ai">Coach IA</string>
+    <string name="paywall_compare_history">Historique et calendrier</string>
+    <string name="paywall_compare_stats">Statistiques</string>
+    <string name="paywall_compare_notifications">Rappels</string>
+    <string name="paywall_compare_photos">Photos de progression</string>
+    <string name="paywall_yearly">Annuel</string>
+    <string name="paywall_monthly">Mensuel</string>
+    <string name="paywall_lifetime">À vie</string>
+    <string name="paywall_best_value">MEILLEUR PRIX</string>
+    <string name="paywall_one_time">PAIEMENT UNIQUE</string>
+    <string name="paywall_price_yearly">$14.99</string>
+    <string name="paywall_price_monthly">$1.99</string>
+    <string name="paywall_price_lifetime">$29.99</string>
+    <string name="paywall_subscribe">Continuer</string>
+    <string name="paywall_restore">Restaurer les achats</string>
 </resources>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -116,4 +116,33 @@
     <string name="progress_empty">Ancora nessuna foto. Tocca + per aggiungere la tua prima foto dei progressi.</string>
     <string name="progress_compare">Confronta</string>
     <string name="progress_delete">Elimina foto</string>
+
+    <!-- Pro / paywall -->
+    <string name="action_close">Chiudi</string>
+    <string name="settings_section_subscription">Abbonamento</string>
+    <string name="settings_upgrade_to_pro">Passa a Pro</string>
+    <string name="settings_restore_purchases">Ripristina acquisti</string>
+    <string name="settings_pro_active">Pro attivo</string>
+    <string name="pro_unlock_button">Sblocca Pro</string>
+    <string name="progress_locked_description">Segui la tua trasformazione con foto mensili e un cursore prima/dopo. Disponibile con Pro.</string>
+    <string name="paywall_title">MuscleCheck Pro</string>
+    <string name="paywall_subtitle">Sblocca le foto dei progressi e sostieni l\'app.</string>
+    <string name="paywall_compare_free">Gratis</string>
+    <string name="paywall_compare_pro">Pro</string>
+    <string name="paywall_compare_checklist">Check-list settimanale</string>
+    <string name="paywall_compare_ai">Coach IA</string>
+    <string name="paywall_compare_history">Cronologia e calendario</string>
+    <string name="paywall_compare_stats">Statistiche</string>
+    <string name="paywall_compare_notifications">Promemoria</string>
+    <string name="paywall_compare_photos">Foto dei progressi</string>
+    <string name="paywall_yearly">Annuale</string>
+    <string name="paywall_monthly">Mensile</string>
+    <string name="paywall_lifetime">A vita</string>
+    <string name="paywall_best_value">MIGLIOR VALORE</string>
+    <string name="paywall_one_time">UNA TANTUM</string>
+    <string name="paywall_price_yearly">$14.99</string>
+    <string name="paywall_price_monthly">$1.99</string>
+    <string name="paywall_price_lifetime">$29.99</string>
+    <string name="paywall_subscribe">Continua</string>
+    <string name="paywall_restore">Ripristina acquisti</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -144,4 +144,33 @@
     <string name="progress_empty">No photos yet. Tap + to add your first progress photo.</string>
     <string name="progress_compare">Compare</string>
     <string name="progress_delete">Delete photo</string>
+
+    <!-- Pro / paywall -->
+    <string name="action_close">Close</string>
+    <string name="settings_section_subscription">Subscription</string>
+    <string name="settings_upgrade_to_pro">Upgrade to Pro</string>
+    <string name="settings_restore_purchases">Restore purchases</string>
+    <string name="settings_pro_active">Pro active</string>
+    <string name="pro_unlock_button">Unlock Pro</string>
+    <string name="progress_locked_description">Track your transformation with monthly photos and a before/after slider. Available with Pro.</string>
+    <string name="paywall_title">MuscleCheck Pro</string>
+    <string name="paywall_subtitle">Unlock progress photos and support the app.</string>
+    <string name="paywall_compare_free">Free</string>
+    <string name="paywall_compare_pro">Pro</string>
+    <string name="paywall_compare_checklist">Weekly checklist</string>
+    <string name="paywall_compare_ai">AI coach</string>
+    <string name="paywall_compare_history">History &amp; calendar</string>
+    <string name="paywall_compare_stats">Statistics</string>
+    <string name="paywall_compare_notifications">Reminders</string>
+    <string name="paywall_compare_photos">Progress photos</string>
+    <string name="paywall_yearly">Yearly</string>
+    <string name="paywall_monthly">Monthly</string>
+    <string name="paywall_lifetime">Lifetime</string>
+    <string name="paywall_best_value">BEST VALUE</string>
+    <string name="paywall_one_time">ONE-TIME</string>
+    <string name="paywall_price_yearly">$14.99</string>
+    <string name="paywall_price_monthly">$1.99</string>
+    <string name="paywall_price_lifetime">$29.99</string>
+    <string name="paywall_subscribe">Continue</string>
+    <string name="paywall_restore">Restore purchases</string>
 </resources>

--- a/android/app/src/test/java/com/zadkiel/musclecheck/ui/pro/PaywallViewModelTest.kt
+++ b/android/app/src/test/java/com/zadkiel/musclecheck/ui/pro/PaywallViewModelTest.kt
@@ -1,0 +1,87 @@
+package com.zadkiel.musclecheck.ui.pro
+
+import com.zadkiel.musclecheck.data.pro.ProAccessManager
+import com.zadkiel.musclecheck.data.pro.ProPackage
+import com.zadkiel.musclecheck.data.pro.ProPurchaseException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PaywallViewModelTest {
+
+    /** Records the purchase call and lets a test force a failure. */
+    private class FakeProAccessManager(private val failWith: String? = null) : ProAccessManager {
+        val proFlag = MutableStateFlow(false)
+        var lastPurchased: ProPackage? = null
+        override val isPro: Flow<Boolean> = proFlag.asStateFlow()
+        override val isLoading: Flow<Boolean> = MutableStateFlow(false).asStateFlow()
+
+        override suspend fun purchase(pkg: ProPackage) {
+            failWith?.let { throw ProPurchaseException(it) }
+            lastPurchased = pkg
+            proFlag.value = true
+        }
+
+        override suspend fun restore() {}
+    }
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `defaults to the yearly package`() {
+        val vm = PaywallViewModel(FakeProAccessManager())
+        assertEquals(ProPackage.YEARLY, vm.selectedPackage.value)
+    }
+
+    @Test
+    fun `purchase buys the selected package and grants pro`() = runTest(dispatcher) {
+        val fake = FakeProAccessManager()
+        val vm = PaywallViewModel(fake)
+
+        vm.select(ProPackage.MONTHLY)
+        vm.purchase()
+        advanceUntilIdle()
+
+        assertEquals(ProPackage.MONTHLY, fake.lastPurchased)
+        assertTrue(fake.proFlag.value)
+        assertNull(vm.error.value)
+    }
+
+    @Test
+    fun `purchase failure surfaces the error message`() = runTest(dispatcher) {
+        val vm = PaywallViewModel(FakeProAccessManager(failWith = "boom"))
+
+        vm.purchase()
+        advanceUntilIdle()
+
+        assertEquals("boom", vm.error.value)
+    }
+
+    @Test
+    fun `clearError resets the error`() = runTest(dispatcher) {
+        val vm = PaywallViewModel(FakeProAccessManager(failWith = "boom"))
+        vm.purchase()
+        advanceUntilIdle()
+
+        vm.clearError()
+
+        assertNull(vm.error.value)
+    }
+}

--- a/docs/PENDING.md
+++ b/docs/PENDING.md
@@ -36,9 +36,12 @@
 - **iOS:** stats de peso por ejercicio (Swift Charts), catálogo ExerciseDB, AI Coach
   sobre ejercicios reales, Apple Watch (Feature 10). Backlog en evaluación: Features 13
   (resto planilla) / 14 / 15 / 16.
-- **Android:** RevenueCat + paywall + gate Pro. **Bloqueado por setup externo:** cuenta
-  Play Console (USD 25 + closed test 14 días), productos en Play Billing, API key pública
-  Android, app Android en el proyecto RevenueCat. Todo lo demás del port ya está hecho.
+- **Android:** la **arquitectura Pro ya está construida** — seam `ProAccessManager`
+  (interface) + `LocalProAccessManager` (stub DataStore con el punto de swap documentado),
+  paywall, gate en progress photos, sección en Settings, strings ES/EN/FR/IT y tests.
+  Lo único que queda es **swappear el stub por el SDK real de RevenueCat** (una sola clase),
+  **bloqueado por setup externo:** cuenta Play Console (USD 25 + closed test 14 días),
+  productos en Play Billing, API key pública Android, app Android en el proyecto RevenueCat.
 
 ## ✅ Cerrado
 

--- a/docs/android-plan.md
+++ b/docs/android-plan.md
@@ -62,10 +62,16 @@ Repo separado: `~/Desktop/sideProjects/musclecheck-android`. Package `com.zadkie
 8. RevenueCat + paywall, localización FR/IT, build final
    - **Localización FR/IT ✅** — `values-fr` y `values-it` completos (116 keys c/u, verificado
      vs EN). Ahora ES/EN/FR/IT como iOS.
-   - **Pendiente (bloqueado por setup externo):** RevenueCat Android (purchases-android) +
-     paywall + gate Pro sobre progress photos/HealthKit. Blockers: cuenta Play Console
-     (USD 25 + closed test), productos en Play Billing, API key pública Android, app Android
-     en el proyecto RevenueCat. Sin eso, el SDK no puede fetchear ofertas → se difiere.
+   - **Arquitectura Pro ✅** — seam `ProAccessManager` (interface) + `LocalProAccessManager`
+     (stub DataStore-backed: `purchase()` prende el flag local; punto de swap a RevenueCat
+     documentado en el archivo), `PaywallScreen`/`PaywallViewModel` (tabla Free-vs-Pro, 3
+     packages, subscribe/restore), `ProLockedCard`, gate en progress photos, sección
+     Subscription en Settings, ruta `PAYWALL`, strings ES/EN/FR/IT (27 keys) y
+     `PaywallViewModelTest` (4 tests). Build + tests verdes.
+   - **Pendiente (bloqueado por setup externo):** swappear el stub por el SDK real de
+     RevenueCat (purchases-android) — con el seam ya armado es un cambio de una sola clase.
+     Blockers: cuenta Play Console (USD 25 + closed test), productos en Play Billing, API key
+     pública Android, app Android en el proyecto RevenueCat. Sin eso el SDK no fetchea ofertas.
 
 ## Blockers externos (requieren acción del developer)
 


### PR DESCRIPTION
## Qué

Última pieza del port Android: la **capa Pro**, espejando el layer de iOS (`StoreManager` / `ProFeatureGate` / `PaywallView`). La app habla solo con una interface `ProAccessManager`, así que wirear el SDK real de RevenueCat luego es un **swap de una sola clase**.

## Cambios

**Seam de entitlement** (`data/pro/`)
- `ProAccessManager` — interface (`isPro`, `isLoading`, `purchase`, `restore`).
- `LocalProAccessManager` — stub DataStore-backed: `purchase()` prende el flag local `isPro`. El **punto de swap a RevenueCat está documentado en el propio archivo**.

**UI** (`ui/pro/`)
- `PaywallScreen` + `PaywallViewModel` — tabla Free-vs-Pro, 3 packages (anual/mensual/lifetime), subscribe con loading, restore, cierre-al-comprar.
- `ProLockedCard` — equivalente al `.card` de iOS.
- Gate en progress photos (no-Pro → card; Pro → galería; FAB/comparador ocultos si no es Pro).
- Sección **Subscription** en Settings, ruta `Routes.PAYWALL`.

**Infra / i18n / tests**
- Flag `isPro` en DataStore + binding Hilt en `AppModule`.
- 27 strings nuevas en **ES/EN/FR/IT**.
- `PaywallViewModelTest` — 4 tests (default package, compra prende Pro, error surface, clearError) con fake manager.

## Pendiente (bloqueado por setup externo)

Swappear el stub por el SDK real de RevenueCat (`purchases-android`). Blockers: cuenta Play Console, productos en Play Billing, API key pública Android, app Android en el proyecto RevenueCat. Con el seam armado es un cambio de una sola clase.

## Verificación

`./gradlew assembleDebug testDebugUnitTest` → **build + tests verdes**, sin warnings nuevos.