### PR TITLE
feat(android): paridad con iOS 2.2.0 — métricas por ejercicio y ejercicios en el grupo

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,8 +14,10 @@ android {
         applicationId = "com.zadkiel.musclecheck"
         minSdk = 26
         targetSdk = 35
+        // Play's own counter (first upload = 1); the name tracks the shared
+        // product version with iOS.
         versionCode = 1
-        versionName = "1.0"
+        versionName = "2.2.0"
     }
 
     buildTypes {

--- a/android/app/src/main/java/com/zadkiel/musclecheck/data/local/AppDatabase.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/data/local/AppDatabase.kt
@@ -7,10 +7,13 @@ import androidx.room.RoomDatabase
     entities = [
         MuscleEntryEntity::class,
         WorkoutSessionEntity::class,
+        ExerciseEntity::class,
+        ExerciseSessionEntity::class,
         CustomCategoryEntity::class,
         ProgressPhotoEntity::class,
     ],
-    version = 2,
+    // v3: per-exercise metrics + exercises inside a group.
+    version = 3,
     exportSchema = false,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/android/app/src/main/java/com/zadkiel/musclecheck/data/local/Entities.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/data/local/Entities.kt
@@ -1,6 +1,5 @@
 package com.zadkiel.musclecheck.data.local
 
-import androidx.room.ColumnInfo
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
@@ -8,6 +7,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.Relation
 import com.zadkiel.musclecheck.domain.model.CustomCategory
+import com.zadkiel.musclecheck.domain.model.Exercise
 import com.zadkiel.musclecheck.domain.model.MuscleEntry
 import com.zadkiel.musclecheck.domain.model.ProgressPhoto
 import com.zadkiel.musclecheck.domain.model.WorkoutSession
@@ -25,6 +25,8 @@ data class MuscleEntryEntity(
     val dateCreated: Long,
     val category: String,
     val icon: String,
+    /** Raw MetricType id; "" = pre-metric entry, resolved from the category at read time. */
+    val metricRaw: String = "",
 )
 
 @Entity(
@@ -47,6 +49,61 @@ data class WorkoutSessionEntity(
     val weightKg: Double?,
     val sets: Int?,
     val reps: Int?,
+    /** Session length in seconds (duration / distanceDuration metrics). */
+    val durationSeconds: Int? = null,
+    /** Distance in meters (distanceDuration metric). */
+    val distanceMeters: Double? = null,
+)
+
+/**
+ * An exercise inside a group. Relational rather than the inline Codable array iOS
+ * uses — same reason `workout_sessions` is its own table: Room is relational and a
+ * blob column would give up querying for nothing.
+ */
+@Entity(
+    tableName = "exercises",
+    foreignKeys = [
+        ForeignKey(
+            entity = MuscleEntryEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["entryId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("entryId")],
+)
+data class ExerciseEntity(
+    @PrimaryKey val id: String,
+    val entryId: String,
+    val name: String,
+    val icon: String,
+    val metricRaw: String,
+    val sortOrder: Int,
+)
+
+/** Per-exercise value history. Separate from `workout_sessions`, which stays the
+ *  group-level "trained that day" record read by streak/stats/widget. */
+@Entity(
+    tableName = "exercise_sessions",
+    foreignKeys = [
+        ForeignKey(
+            entity = ExerciseEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["exerciseId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("exerciseId")],
+)
+data class ExerciseSessionEntity(
+    @PrimaryKey val id: String,
+    val exerciseId: String,
+    val epochDay: Long,
+    val weightKg: Double?,
+    val sets: Int?,
+    val reps: Int?,
+    val durationSeconds: Int?,
+    val distanceMeters: Double?,
 )
 
 @Entity(tableName = "custom_categories")
@@ -55,7 +112,9 @@ data class CustomCategoryEntity(
     val name: String,
     val icon: String,
     val sortOrder: Int,
+    /** Legacy Feature-17 flag; migration source for [defaultMetricRaw]. */
     val tracksWeight: Boolean,
+    val defaultMetricRaw: String = "",
 )
 
 /** Progress photo metadata; the image itself lives on disk (internal storage),
@@ -67,10 +126,18 @@ data class ProgressPhotoEntity(
     val fileName: String,
 )
 
+data class ExerciseWithSessions(
+    @Embedded val exercise: ExerciseEntity,
+    @Relation(parentColumn = "id", entityColumn = "exerciseId")
+    val sessions: List<ExerciseSessionEntity>,
+)
+
 data class EntryWithSessions(
     @Embedded val entry: MuscleEntryEntity,
     @Relation(parentColumn = "id", entityColumn = "entryId")
     val sessions: List<WorkoutSessionEntity>,
+    @Relation(parentColumn = "id", entityColumn = "entryId", entity = ExerciseEntity::class)
+    val exercises: List<ExerciseWithSessions>,
 )
 
 // MARK: - Mapping to domain
@@ -85,6 +152,16 @@ fun EntryWithSessions.toDomain(): MuscleEntry = MuscleEntry(
     category = entry.category,
     icon = entry.icon,
     sessions = sessions.map { it.toDomain() }.sortedBy { it.date },
+    metricRaw = entry.metricRaw,
+    exercises = exercises.sortedBy { it.exercise.sortOrder }.map { it.toDomain() },
+)
+
+fun ExerciseWithSessions.toDomain(): Exercise = Exercise(
+    id = exercise.id,
+    name = exercise.name,
+    icon = exercise.icon,
+    metricRaw = exercise.metricRaw,
+    sessions = sessions.map { it.toDomain() }.sortedBy { it.date },
 )
 
 fun WorkoutSessionEntity.toDomain(): WorkoutSession = WorkoutSession(
@@ -93,6 +170,18 @@ fun WorkoutSessionEntity.toDomain(): WorkoutSession = WorkoutSession(
     weightKg = weightKg,
     sets = sets,
     reps = reps,
+    durationSeconds = durationSeconds,
+    distanceMeters = distanceMeters,
+)
+
+fun ExerciseSessionEntity.toDomain(): WorkoutSession = WorkoutSession(
+    id = id,
+    date = LocalDate.ofEpochDay(epochDay),
+    weightKg = weightKg,
+    sets = sets,
+    reps = reps,
+    durationSeconds = durationSeconds,
+    distanceMeters = distanceMeters,
 )
 
 fun CustomCategoryEntity.toDomain(): CustomCategory = CustomCategory(
@@ -101,6 +190,7 @@ fun CustomCategoryEntity.toDomain(): CustomCategory = CustomCategory(
     icon = icon,
     sortOrder = sortOrder,
     tracksWeight = tracksWeight,
+    defaultMetricRaw = defaultMetricRaw,
 )
 
 fun ProgressPhotoEntity.toDomain(): ProgressPhoto = ProgressPhoto(

--- a/android/app/src/main/java/com/zadkiel/musclecheck/data/local/MuscleDao.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/data/local/MuscleDao.kt
@@ -18,7 +18,8 @@ interface MuscleDao {
     @Query("SELECT * FROM muscle_entries ORDER BY dateCreated")
     suspend fun getEntriesWithSessions(): List<EntryWithSessions>
 
-    @Query("SELECT COUNT(*) FROM muscle_entries WHERE name = :name")
+    /** Case-insensitive, matching the unified duplicate rule of iOS `normalizedName`. */
+    @Query("SELECT COUNT(*) FROM muscle_entries WHERE name = :name COLLATE NOCASE")
     suspend fun countByName(name: String): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -46,6 +47,33 @@ interface MuscleDao {
 
     @Query("SELECT * FROM workout_sessions WHERE entryId = :entryId ORDER BY epochDay DESC")
     suspend fun sessionsFor(entryId: String): List<WorkoutSessionEntity>
+
+    @Query("UPDATE muscle_entries SET metricRaw = :metricRaw WHERE id = :id")
+    suspend fun setMetric(id: String, metricRaw: String)
+
+    /** Entries created before per-exercise metrics existed (backfilled at startup). */
+    @Query("SELECT * FROM muscle_entries WHERE metricRaw = ''")
+    suspend fun entriesWithoutMetric(): List<MuscleEntryEntity>
+
+    // MARK: - Exercises
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertExercise(exercise: ExerciseEntity)
+
+    @Query("DELETE FROM exercises WHERE id = :id")
+    suspend fun deleteExercise(id: String)
+
+    @Query("SELECT COALESCE(MAX(sortOrder), -1) FROM exercises WHERE entryId = :entryId")
+    suspend fun maxExerciseOrder(entryId: String): Int
+
+    @Query("SELECT COUNT(*) FROM exercises WHERE entryId = :entryId AND name = :name COLLATE NOCASE")
+    suspend fun countExerciseByName(entryId: String, name: String): Int
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertExerciseSession(session: ExerciseSessionEntity)
+
+    @Query("SELECT * FROM exercise_sessions WHERE exerciseId = :exerciseId AND epochDay = :epochDay LIMIT 1")
+    suspend fun exerciseSessionOn(exerciseId: String, epochDay: Long): ExerciseSessionEntity?
 }
 
 @Dao

--- a/android/app/src/main/java/com/zadkiel/musclecheck/data/repository/MuscleRepository.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/data/repository/MuscleRepository.kt
@@ -3,6 +3,8 @@ package com.zadkiel.musclecheck.data.repository
 import android.content.Context
 import com.zadkiel.musclecheck.data.local.CategoryDao
 import com.zadkiel.musclecheck.data.local.CustomCategoryEntity
+import com.zadkiel.musclecheck.data.local.ExerciseEntity
+import com.zadkiel.musclecheck.data.local.ExerciseSessionEntity
 import com.zadkiel.musclecheck.data.local.MuscleDao
 import com.zadkiel.musclecheck.data.local.MuscleEntryEntity
 import com.zadkiel.musclecheck.data.local.WorkoutSessionEntity
@@ -11,7 +13,9 @@ import com.zadkiel.musclecheck.data.prefs.UserPreferencesRepository
 import com.zadkiel.musclecheck.domain.AppWeek
 import com.zadkiel.musclecheck.domain.model.ActivityCategory
 import com.zadkiel.musclecheck.domain.model.CustomCategory
+import com.zadkiel.musclecheck.domain.model.MetricType
 import com.zadkiel.musclecheck.domain.model.MuscleEntry
+import com.zadkiel.musclecheck.domain.model.SessionInput
 import com.zadkiel.musclecheck.R
 import com.zadkiel.musclecheck.widget.MuscleCheckWidget
 import androidx.glance.appwidget.updateAll
@@ -44,12 +48,15 @@ class MuscleRepository @Inject constructor(
 
     // MARK: - Entries
 
-    /** Adds a new entry, trimming the name and rejecting duplicates. */
-    suspend fun addEntry(name: String, category: String, icon: String) {
+    /**
+     * Adds a new entry, trimming the name and rejecting duplicates. [metric] defaults to
+     * the category's default when not overridden at creation.
+     */
+    suspend fun addEntry(name: String, category: String, icon: String, metric: MetricType? = null) {
         val trimmed = name.trim()
         if (trimmed.isEmpty()) throw InvalidNameException()
         if (muscleDao.countByName(trimmed) > 0) throw DuplicateEntryException(trimmed)
-        muscleDao.insertEntry(newEntryEntity(trimmed, category, icon))
+        muscleDao.insertEntry(newEntryEntity(trimmed, category, icon, metric ?: defaultMetricFor(category)))
         refreshWidget()
     }
 
@@ -58,10 +65,35 @@ class MuscleRepository @Inject constructor(
         for (preset in category.presetEntries) {
             val name = context.getString(preset.nameRes).trim()
             if (name.isEmpty() || muscleDao.countByName(name) > 0) continue
-            muscleDao.insertEntry(newEntryEntity(name, category.id, preset.icon))
+            muscleDao.insertEntry(newEntryEntity(name, category.id, preset.icon, category.defaultMetric))
         }
         prefs.markPresetAdded(category.id)
         refreshWidget()
+    }
+
+    /** Adds a single preset entry (one-tap add from the unified add screen). */
+    suspend fun addPresetEntry(category: ActivityCategory, nameRes: Int, icon: String) {
+        val name = context.getString(nameRes).trim()
+        if (name.isEmpty() || muscleDao.countByName(name) > 0) return
+        muscleDao.insertEntry(newEntryEntity(name, category.id, icon, category.defaultMetric))
+        refreshWidget()
+    }
+
+    /**
+     * Resolves the metric of entries created before metrics existed and persists it, so
+     * the lazy category fallback runs exactly once per entry. Idempotent (the query only
+     * matches empty metrics), mirroring the iOS `backfillMetricTypes` at startup.
+     */
+    suspend fun backfillMetricTypes() {
+        val pending = muscleDao.entriesWithoutMetric()
+        if (pending.isEmpty()) return
+        val customs = categoryDao.getAll().map { it.toDomain() }
+        for (entry in pending) {
+            val metric = ActivityCategory.fromId(entry.category)?.defaultMetric
+                ?: customs.firstOrNull { it.id == entry.category }?.defaultMetric
+                ?: MetricType.NONE
+            muscleDao.setMetric(entry.id, metric.id)
+        }
     }
 
     suspend fun deleteEntry(id: String) {
@@ -102,9 +134,7 @@ class MuscleRepository @Inject constructor(
      */
     suspend fun saveTodaySession(
         entryId: String,
-        weightKg: Double?,
-        sets: Int?,
-        reps: Int?,
+        input: SessionInput,
         today: LocalDate = LocalDate.now(),
     ) {
         val existing = muscleDao.sessionOn(entryId, today.toEpochDay())
@@ -113,11 +143,80 @@ class MuscleRepository @Inject constructor(
                 id = existing?.id ?: UUID.randomUUID().toString(),
                 entryId = entryId,
                 epochDay = today.toEpochDay(),
-                weightKg = weightKg,
-                sets = sets,
-                reps = reps,
+                weightKg = input.weightKg,
+                sets = input.sets,
+                reps = input.reps,
+                durationSeconds = input.durationSeconds,
+                distanceMeters = input.distanceMeters,
             )
         )
+        muscleDao.setChecked(entryId, true)
+        refreshWidget()
+    }
+
+    // MARK: - Exercises (detail layer inside a group)
+
+    /** Appends an exercise to a group. Duplicate names within the group are rejected. */
+    suspend fun addExercise(entryId: String, name: String, metric: MetricType, icon: String) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) throw InvalidNameException()
+        if (muscleDao.countExerciseByName(entryId, trimmed) > 0) throw DuplicateEntryException(trimmed)
+        muscleDao.insertExercise(
+            ExerciseEntity(
+                id = UUID.randomUUID().toString(),
+                entryId = entryId,
+                name = trimmed,
+                icon = icon,
+                metricRaw = metric.id,
+                sortOrder = muscleDao.maxExerciseOrder(entryId) + 1,
+            )
+        )
+        refreshWidget()
+    }
+
+    suspend fun deleteExercise(id: String) {
+        muscleDao.deleteExercise(id)
+        refreshWidget()
+    }
+
+    /**
+     * Logs today's values for one exercise AND marks the GROUP trained today, so the
+     * weekly check / streak / stats / widget (which read the group's sessions) keep
+     * working untouched. Upserts today's session (no duplicate per day).
+     */
+    suspend fun logExercise(
+        entryId: String,
+        exerciseId: String,
+        input: SessionInput,
+        today: LocalDate = LocalDate.now(),
+    ) {
+        val epochDay = today.toEpochDay()
+        val existing = muscleDao.exerciseSessionOn(exerciseId, epochDay)
+        muscleDao.insertExerciseSession(
+            ExerciseSessionEntity(
+                id = existing?.id ?: UUID.randomUUID().toString(),
+                exerciseId = exerciseId,
+                epochDay = epochDay,
+                weightKg = input.weightKg,
+                sets = input.sets,
+                reps = input.reps,
+                durationSeconds = input.durationSeconds,
+                distanceMeters = input.distanceMeters,
+            )
+        )
+        // The group counts as trained today (drives check / streak / stats / history).
+        if (muscleDao.sessionOn(entryId, epochDay) == null) {
+            muscleDao.insertSession(
+                WorkoutSessionEntity(
+                    id = UUID.randomUUID().toString(),
+                    entryId = entryId,
+                    epochDay = epochDay,
+                    weightKg = null,
+                    sets = null,
+                    reps = null,
+                )
+            )
+        }
         muscleDao.setChecked(entryId, true)
         refreshWidget()
     }
@@ -135,7 +234,7 @@ class MuscleRepository @Inject constructor(
 
     // MARK: - Custom categories
 
-    suspend fun addCustomCategory(name: String, icon: String, tracksWeight: Boolean) {
+    suspend fun addCustomCategory(name: String, icon: String, defaultMetric: MetricType) {
         val trimmed = name.trim()
         if (trimmed.isEmpty()) throw InvalidNameException()
         val existing = categoryDao.getAll()
@@ -148,8 +247,9 @@ class MuscleRepository @Inject constructor(
                 id = UUID.randomUUID().toString(),
                 name = trimmed,
                 icon = icon,
+                tracksWeight = defaultMetric == MetricType.STRENGTH,
                 sortOrder = nextOrder,
-                tracksWeight = tracksWeight,
+                defaultMetricRaw = defaultMetric.id,
             )
         )
     }
@@ -175,7 +275,12 @@ class MuscleRepository @Inject constructor(
         MuscleCheckWidget().updateAll(context)
     }
 
-    private fun newEntryEntity(name: String, category: String, icon: String): MuscleEntryEntity {
+    private fun newEntryEntity(
+        name: String,
+        category: String,
+        icon: String,
+        metric: MetricType,
+    ): MuscleEntryEntity {
         val today = LocalDate.now()
         return MuscleEntryEntity(
             id = UUID.randomUUID().toString(),
@@ -186,8 +291,15 @@ class MuscleRepository @Inject constructor(
             dateCreated = Instant.now().toEpochMilli(),
             category = category,
             icon = icon,
+            metricRaw = metric.id,
         )
     }
+
+    /** Category default for a category id that may be built-in or custom. */
+    private suspend fun defaultMetricFor(categoryId: String): MetricType =
+        ActivityCategory.fromId(categoryId)?.defaultMetric
+            ?: categoryDao.getAll().firstOrNull { it.id == categoryId }?.toDomain()?.defaultMetric
+            ?: MetricType.NONE
 
     /** Localized error message matching the iOS copy. */
     fun errorMessage(e: Exception): String = when (e) {

--- a/android/app/src/main/java/com/zadkiel/musclecheck/domain/MonthCalendarCalculator.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/domain/MonthCalendarCalculator.kt
@@ -1,6 +1,8 @@
 package com.zadkiel.musclecheck.domain
 
+import com.zadkiel.musclecheck.domain.model.Exercise
 import com.zadkiel.musclecheck.domain.model.MuscleEntry
+import com.zadkiel.musclecheck.domain.model.WorkoutSession
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.TextStyle
@@ -9,8 +11,21 @@ import java.util.Locale
 /** One cell in the month grid; `isInDisplayedMonth` is false for adjacent-month spill days. */
 data class CalendarDay(val date: LocalDate, val isInDisplayedMonth: Boolean)
 
-/** One trained muscle on a given day, carrying THAT day's logged weight (kg, may be null). */
-data class DayActivity(val entry: MuscleEntry, val weightKg: Double?)
+/**
+ * One trained group on a given day. Carries that day's group-level session plus any
+ * exercises logged the same day, so the week detail can show per-exercise values
+ * ("Peso muerto 100 kg") instead of a single number per group.
+ */
+data class DayActivity(
+    val entry: MuscleEntry,
+    val session: WorkoutSession?,
+    val exercises: List<ExerciseOnDay> = emptyList(),
+) {
+    val weightKg: Double? get() = session?.weightKg
+}
+
+/** An exercise logged on a given day, with that day's values. */
+data class ExerciseOnDay(val exercise: Exercise, val session: WorkoutSession)
 
 /** The activities trained on a single day, used by the week detail breakdown. */
 data class DayActivities(val date: LocalDate, val activities: List<DayActivity>)
@@ -82,8 +97,12 @@ object MonthCalendarCalculator {
             val day = monday.plusDays(offset.toLong())
             val activities = entries
                 .mapNotNull { entry ->
-                    entry.sessions.firstOrNull { it.date == day }
-                        ?.let { session -> DayActivity(entry, session.weightKg) }
+                    val session = entry.sessions.firstOrNull { it.date == day } ?: return@mapNotNull null
+                    val exercises = entry.exercises.mapNotNull { exercise ->
+                        exercise.sessions.firstOrNull { it.date == day }
+                            ?.let { ExerciseOnDay(exercise, it) }
+                    }
+                    DayActivity(entry, session, exercises)
                 }
                 .sortedBy { it.entry.name }
             if (activities.isEmpty()) null else DayActivities(day, activities)

--- a/android/app/src/main/java/com/zadkiel/musclecheck/domain/model/ActivityCategory.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/domain/model/ActivityCategory.kt
@@ -23,7 +23,21 @@ enum class ActivityCategory(
     CUSTOM("custom", R.string.category_custom, "star.fill");
 
     /** Whether activities in this category prompt for/show weight. Only gym among built-ins. */
+    @Deprecated("Superseded by defaultMetric (per-exercise metrics)", ReplaceWith("defaultMetric"))
     val tracksWeight: Boolean get() = this == GYM
+
+    /**
+     * Default metric for NEW entries in this category. The metric lives on each entry
+     * ([MuscleEntry.metric]) and can be overridden at creation — this is only the
+     * starting point, and the lazy fallback for pre-metric entries.
+     */
+    val defaultMetric: MetricType
+        get() = when (this) {
+            GYM -> MetricType.STRENGTH
+            RUNNING -> MetricType.DISTANCE_DURATION
+            CARDIO, YOGA, PILATES -> MetricType.DURATION
+            CALISTHENICS, STRETCHING, CUSTOM -> MetricType.NONE
+        }
 
     val sortOrder: Int get() = ordinal
 

--- a/android/app/src/main/java/com/zadkiel/musclecheck/domain/model/MetricType.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/domain/model/MetricType.kt
@@ -1,0 +1,80 @@
+package com.zadkiel.musclecheck.domain.model
+
+import androidx.annotation.StringRes
+import com.zadkiel.musclecheck.R
+
+/**
+ * What a single exercise logs when checked, decided PER ENTRY (not per category —
+ * the category only provides the default for new entries). Determines which fields
+ * the session log sheet shows. Port of the iOS `MetricType` (same rawValues, so
+ * entries created on either platform resolve identically).
+ */
+enum class MetricType(
+    val id: String,
+    @StringRes val displayNameRes: Int,
+) {
+    /** Check only — no session log. */
+    NONE("none", R.string.metric_type_none),
+
+    /** Weight + sets + reps (the original gym behavior). */
+    STRENGTH("strength", R.string.metric_type_strength),
+
+    /** Time only (plank, a yoga session). */
+    DURATION("duration", R.string.metric_type_duration),
+
+    /** Distance + time (running, cycling). */
+    DISTANCE_DURATION("distanceDuration", R.string.metric_type_distance_duration);
+
+    /** Whether opening the session log for this metric makes sense at all. */
+    val logsSomething: Boolean get() = this != NONE
+
+    companion object {
+        fun fromId(id: String?): MetricType? = entries.firstOrNull { it.id == id }
+    }
+}
+
+/**
+ * Display formatting for session values. Single source for the metric labels shown
+ * on home rows AND history rows, so separator/order/empty-handling can't drift.
+ * Duration/distance are unit-invariant for v1 — minutes and km only, mirroring how
+ * "kg"/"lbs" labels are literal.
+ *
+ * Pure (the unit is passed in, not read from prefs) so it stays JVM-testable, unlike
+ * the iOS twin which reads UserDefaults directly.
+ */
+object SessionFormatting {
+
+    /** "45 min" — whole minutes, storage is seconds. */
+    fun formatDuration(seconds: Int): String = "${seconds / 60} min"
+
+    /** "5.2 km" — one decimal, storage is meters. */
+    fun formatDistance(meters: Double): String = String.format("%.1f km", meters / 1000)
+
+    /** "20 kg" / "44 lbs" — whole numbers in the user's display unit; storage is kg. */
+    fun formatWeight(kg: Double, unit: WeightUnit): String =
+        String.format("%.0f", unit.displayValue(kg)) + " " + unit.displayLabel
+
+    /**
+     * The label for a set of session values under a given metric: "20 kg",
+     * "45 min", "5.2 km · 32 min". Null when the metric logs nothing or no
+     * relevant value is present.
+     */
+    fun label(
+        metric: MetricType,
+        weightKg: Double? = null,
+        durationSeconds: Int? = null,
+        distanceMeters: Double? = null,
+        unit: WeightUnit = WeightUnit.KG,
+    ): String? = when (metric) {
+        MetricType.NONE -> null
+        MetricType.STRENGTH -> weightKg?.let { formatWeight(it, unit) }
+        MetricType.DURATION -> durationSeconds?.let { formatDuration(it) }
+        MetricType.DISTANCE_DURATION -> {
+            val parts = listOfNotNull(
+                distanceMeters?.let { formatDistance(it) },
+                durationSeconds?.let { formatDuration(it) },
+            )
+            parts.takeIf { it.isNotEmpty() }?.joinToString(" · ")
+        }
+    }
+}

--- a/android/app/src/main/java/com/zadkiel/musclecheck/domain/model/Models.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/domain/model/Models.kt
@@ -3,13 +3,27 @@ package com.zadkiel.musclecheck.domain.model
 import java.time.Instant
 import java.time.LocalDate
 
-/** One logged session. Weight is ALWAYS stored in kg; conversion happens at the UI edges. */
+/**
+ * One logged session. Weight is ALWAYS stored in kg, distance in meters, duration in
+ * seconds (canonical units); conversion happens at the UI edges.
+ */
 data class WorkoutSession(
     val id: String,
     val date: LocalDate,
     val weightKg: Double? = null,
     val sets: Int? = null,
     val reps: Int? = null,
+    val durationSeconds: Int? = null,
+    val distanceMeters: Double? = null,
+)
+
+/** Everything the session-log sheet can capture in one save, in canonical units. */
+data class SessionInput(
+    val weightKg: Double? = null,
+    val sets: Int? = null,
+    val reps: Int? = null,
+    val durationSeconds: Int? = null,
+    val distanceMeters: Double? = null,
 )
 
 /** A progress photo. The image is on disk (`fileName` under the app's photos dir);
@@ -19,6 +33,63 @@ data class ProgressPhoto(
     val date: LocalDate,
     val fileName: String,
 )
+
+/**
+ * A named exercise inside a group (e.g. "Peso muerto" under "Piernas"), each with its
+ * own metric and value history. The group keeps its own `sessions` for the WEEKLY
+ * CHECK / date semantics (streak, stats, notifications all read those) — exercises are
+ * a DETAIL layer. Logging an exercise also marks the group trained that day.
+ */
+data class Exercise(
+    val id: String,
+    val name: String,
+    val icon: String,
+    /** Raw [MetricType] id. Each exercise logs its OWN thing, independent of the group. */
+    val metricRaw: String,
+    val sessions: List<WorkoutSession> = emptyList(),
+) {
+    val metric: MetricType get() = MetricType.fromId(metricRaw) ?: MetricType.STRENGTH
+
+    /** Most recent session for which [value] is non-null — single scan. */
+    private fun <T> latestValue(value: (WorkoutSession) -> T?): T? {
+        var best: Pair<LocalDate, T>? = null
+        for (session in sessions) {
+            val v = value(session) ?: continue
+            if (best == null || session.date > best.first) best = session.date to v
+        }
+        return best?.second
+    }
+
+    val lastWeightKg: Double? get() = latestValue { it.weightKg }
+    val lastSets: Int? get() = latestValue { it.sets }
+    val lastReps: Int? get() = latestValue { it.reps }
+    val lastDurationSeconds: Int? get() = latestValue { it.durationSeconds }
+    val lastDistanceMeters: Double? get() = latestValue { it.distanceMeters }
+
+    /**
+     * Most recent session recording distance OR duration — read BOTH values from this
+     * one session so a distance from one day and a time from another aren't paired as
+     * if they had been done together.
+     */
+    val lastDistanceDurationSession: WorkoutSession?
+        get() = sessions.filter { it.distanceMeters != null || it.durationSeconds != null }
+            .maxByOrNull { it.date }
+
+    val lastTrainedDate: LocalDate? get() = sessions.maxOfOrNull { it.date }
+
+    /** Row label for this exercise under the group ("100 kg", "45 min", "5.2 km · 32 min"). */
+    fun summary(unit: WeightUnit): String? = SessionFormatting.label(
+        metric = metric,
+        weightKg = lastWeightKg,
+        durationSeconds = if (metric == MetricType.DISTANCE_DURATION) {
+            lastDistanceDurationSession?.durationSeconds
+        } else {
+            lastDurationSeconds
+        },
+        distanceMeters = lastDistanceDurationSession?.distanceMeters,
+        unit = unit,
+    )
+}
 
 /** Domain mirror of the iOS `MuscleEntry` SwiftData model. */
 data class MuscleEntry(
@@ -31,6 +102,13 @@ data class MuscleEntry(
     val category: String,
     val icon: String,
     val sessions: List<WorkoutSession> = emptyList(),
+    /**
+     * Raw [MetricType] id. Empty string = pre-metric entry, resolved lazily from the
+     * category (and persisted by the startup backfill) — the same additive-migration
+     * trick iOS uses, so entries created before this feature keep working.
+     */
+    val metricRaw: String = "",
+    val exercises: List<Exercise> = emptyList(),
 ) {
     /** Most recent recorded weight (kg), looking back across sessions. Null if never recorded. */
     val lastWeightKg: Double?
@@ -44,16 +122,73 @@ data class MuscleEntry(
 
     val lastTrainedDate: LocalDate?
         get() = sessions.maxOfOrNull { it.date }
+
+    /**
+     * This group's metric. Falls back to the built-in category's default for entries
+     * created before metrics existed; custom categories need the resolver, so callers
+     * holding custom categories should use [metricResolving].
+     */
+    val metric: MetricType
+        get() = MetricType.fromId(metricRaw)
+            ?: ActivityCategory.fromId(category)?.defaultMetric
+            ?: MetricType.NONE
+
+    /** [metric], but able to fall back to a CUSTOM category's default too. */
+    fun metricResolving(customCategories: List<CustomCategory>): MetricType =
+        MetricType.fromId(metricRaw)
+            ?: ActivityCategory.fromId(category)?.defaultMetric
+            ?: customCategories.firstOrNull { it.id == category }?.defaultMetric
+            ?: MetricType.NONE
+
+    /**
+     * Row label under the group name. With exercises: count + the most recently logged
+     * one. Without exercises, falls back to the group's own single-value label so
+     * nothing regresses for entries that never used the detail layer.
+     */
+    fun summary(unit: WeightUnit): EntrySummary? {
+        if (exercises.isEmpty()) {
+            val own = SessionFormatting.label(metric = metric, weightKg = lastWeightKg, unit = unit)
+            return own?.let { EntrySummary(exerciseCount = 0, ownLabel = it) }
+        }
+        val recent = exercises.maxByOrNull { it.lastTrainedDate ?: LocalDate.MIN }
+        val value = recent?.summary(unit)
+        return EntrySummary(
+            exerciseCount = exercises.size,
+            recentName = if (value != null) recent.name else null,
+            recentValue = value,
+        )
+    }
 }
 
-/** A category the user creates beyond the built-in `ActivityCategory` cases. */
+/**
+ * Pieces of a group's row label. The UI assembles the final string because the
+ * "N exercises" part needs a plural resource, which is a platform concern.
+ */
+data class EntrySummary(
+    val exerciseCount: Int,
+    val recentName: String? = null,
+    val recentValue: String? = null,
+    val ownLabel: String? = null,
+)
+
+/** A category the user creates beyond the built-in [ActivityCategory] cases. */
 data class CustomCategory(
     val id: String,
     val name: String,
     val icon: String,
     val sortOrder: Int,
+    /**
+     * Legacy Feature-17 flag, kept as the migration source for [defaultMetricRaw] on
+     * categories created before per-exercise metrics existed.
+     */
     val tracksWeight: Boolean,
-)
+    val defaultMetricRaw: String = "",
+) {
+    /** Default metric for new entries in this category. */
+    val defaultMetric: MetricType
+        get() = MetricType.fromId(defaultMetricRaw)
+            ?: if (tracksWeight) MetricType.STRENGTH else MetricType.NONE
+}
 
 /** User preference for weight display. Storage is always kg. */
 enum class WeightUnit(val id: String, val displayLabel: String) {

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/history/HistoryScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -49,6 +50,7 @@ import com.zadkiel.musclecheck.domain.DayActivities
 import com.zadkiel.musclecheck.domain.MonthCalendarCalculator
 import com.zadkiel.musclecheck.domain.AppWeek
 import com.zadkiel.musclecheck.domain.model.CategoryResolver
+import com.zadkiel.musclecheck.domain.model.SessionFormatting
 import com.zadkiel.musclecheck.domain.model.CustomCategory
 import com.zadkiel.musclecheck.domain.model.WeightUnit
 import com.zadkiel.musclecheck.ui.icons.AppIcons
@@ -87,7 +89,12 @@ fun HistoryScreen(
         ) {
             // Month summary caption
             Text(
-                text = stringResource(R.string.history_month_summary, state.monthTrainedCount, state.monthName),
+                text = pluralStringResource(
+                    R.plurals.history_month_summary_plural,
+                    state.monthTrainedCount,
+                    state.monthTrainedCount,
+                    state.monthName,
+                ),
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp),
@@ -369,9 +376,7 @@ private fun WeekDetailSection(
                     color = MaterialTheme.colorScheme.primary,
                 )
                 day.activities.forEach { activity ->
-                    val tracksWeight = remember(activity.entry.category, customCategories) {
-                        CategoryResolver.resolve(activity.entry.category, customCategories, context).tracksWeight
-                    }
+                    val metric = activity.entry.metricResolving(customCategories)
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -383,13 +388,39 @@ private fun WeekDetailSection(
                             modifier = Modifier.size(20.dp),
                         )
                         Text(activity.entry.name, style = MaterialTheme.typography.bodyLarge)
-                        if (tracksWeight && activity.weightKg != null) {
-                            Text(
-                                text = "${weightUnit.displayValue(activity.weightKg).roundToInt()} ${weightUnit.displayLabel}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+                        // With no exercises logged that day, fall back to the group's
+                        // own value so pre-exercise history still reads the same.
+                        if (activity.exercises.isEmpty()) {
+                            SessionFormatting.label(
+                                metric = metric,
+                                weightKg = activity.session?.weightKg,
+                                durationSeconds = activity.session?.durationSeconds,
+                                distanceMeters = activity.session?.distanceMeters,
+                                unit = weightUnit,
+                            )?.let { label ->
+                                Text(
+                                    text = label,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                         }
+                    }
+                    // Per-exercise lines, indented under the group.
+                    activity.exercises.forEach { logged ->
+                        val label = SessionFormatting.label(
+                            metric = logged.exercise.metric,
+                            weightKg = logged.session.weightKg,
+                            durationSeconds = logged.session.durationSeconds,
+                            distanceMeters = logged.session.distanceMeters,
+                            unit = weightUnit,
+                        )
+                        Text(
+                            text = listOfNotNull(logged.exercise.name, label).joinToString(" "),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(start = 32.dp),
+                        )
                     }
                 }
             }

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/AddEntrySheet.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/AddEntrySheet.kt
@@ -1,21 +1,27 @@
 package com.zadkiel.musclecheck.ui.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -23,6 +29,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -34,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -42,153 +50,429 @@ import com.zadkiel.musclecheck.R
 import com.zadkiel.musclecheck.domain.model.ActivityCategory
 import com.zadkiel.musclecheck.domain.model.CategoryResolver
 import com.zadkiel.musclecheck.domain.model.CustomCategory
+import com.zadkiel.musclecheck.domain.model.MetricType
+import com.zadkiel.musclecheck.domain.model.MuscleEntry
 import com.zadkiel.musclecheck.ui.icons.AppIcons
 
-/** Port of AddMuscleGroupView: name + category picker + icon grid. */
+/**
+ * Unified add flow, as a PICKER rather than a form (recognition over recall): category
+ * chips on top, tappable rows of that category's presets below — tap = added, with the
+ * row flipping to a check so multi-add needs no trips back and forth. Free-text names
+ * live behind "create your own", and a new category can be created inline.
+ *
+ * Port of the iOS `AddExerciseView` (Feature 18).
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddEntrySheet(
+    entries: List<MuscleEntry>,
     customCategories: List<CustomCategory>,
     errorMessage: String?,
-    onSave: (name: String, category: String, icon: String) -> Unit,
+    /** Last category used, so the sheet reopens where the user left off. */
+    initialCategoryId: String,
+    onCategorySelected: (String) -> Unit,
+    onAddPreset: (ActivityCategory, Int, String) -> Unit,
+    onAddCustom: (name: String, category: String, icon: String, metric: MetricType) -> Unit,
+    onRemoveEntry: (MuscleEntry) -> Unit,
+    onCreateCategory: (name: String, icon: String, metric: MetricType) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
-    var name by remember { mutableStateOf("") }
-    var selectedCategoryId by remember { mutableStateOf(ActivityCategory.GYM.id) }
-    var selectedIcon by remember { mutableStateOf(ActivityCategory.GYM.defaultIcon) }
-    var categoryMenuExpanded by remember { mutableStateOf(false) }
+    var selectedCategoryId by remember { mutableStateOf(initialCategoryId) }
+    var creatingOwn by remember { mutableStateOf(false) }
+    var creatingCategory by remember { mutableStateOf(false) }
 
-    val selectedCategoryLabel = remember(selectedCategoryId, customCategories) {
-        CategoryResolver.resolve(selectedCategoryId, customCategories, context).displayName
-    }
+    val builtIn = remember(selectedCategoryId) { ActivityCategory.fromId(selectedCategoryId) }
+    val isGym = builtIn == ActivityCategory.GYM
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 32.dp),
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
         ) {
             Text(
-                text = stringResource(R.string.add_exercise),
+                text = stringResource(R.string.add_sheet_title),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
             )
-            Spacer(Modifier.height(20.dp))
-
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                placeholder = { Text(stringResource(R.string.new_exercise_placeholder)) },
-                label = { Text(stringResource(R.string.add_exercise)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
             Spacer(Modifier.height(16.dp))
 
-            ExposedDropdownMenuBox(
-                expanded = categoryMenuExpanded,
-                onExpandedChange = { categoryMenuExpanded = it },
+            // Category chips.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                OutlinedTextField(
-                    value = selectedCategoryLabel,
-                    onValueChange = {},
-                    readOnly = true,
-                    label = { Text(stringResource(R.string.select_category)) },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = categoryMenuExpanded) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .menuAnchor(),
-                )
-                ExposedDropdownMenu(
-                    expanded = categoryMenuExpanded,
-                    onDismissRequest = { categoryMenuExpanded = false },
-                ) {
-                    ActivityCategory.entries.forEach { category ->
-                        DropdownMenuItem(
-                            text = { Text(stringResource(category.displayNameRes)) },
-                            leadingIcon = { Icon(AppIcons.forKey(category.defaultIcon), contentDescription = null) },
-                            onClick = {
-                                selectedCategoryId = category.id
-                                selectedIcon = category.defaultIcon
-                                categoryMenuExpanded = false
-                            },
-                        )
-                    }
-                    customCategories.forEach { category ->
-                        DropdownMenuItem(
-                            text = { Text(category.name) },
-                            leadingIcon = { Icon(AppIcons.forKey(category.icon), contentDescription = null) },
-                            onClick = {
-                                selectedCategoryId = category.id
-                                selectedIcon = category.icon
-                                categoryMenuExpanded = false
-                            },
-                        )
-                    }
+                ActivityCategory.entries.filter { it != ActivityCategory.CUSTOM }.forEach { category ->
+                    CategoryChip(
+                        name = stringResource(category.displayNameRes),
+                        icon = category.defaultIcon,
+                        selected = selectedCategoryId == category.id,
+                        onClick = {
+                            selectedCategoryId = category.id
+                            onCategorySelected(category.id)
+                        },
+                    )
                 }
+                customCategories.forEach { category ->
+                    CategoryChip(
+                        name = category.name,
+                        icon = category.icon,
+                        selected = selectedCategoryId == category.id,
+                        onClick = {
+                            selectedCategoryId = category.id
+                            onCategorySelected(category.id)
+                        },
+                    )
+                }
+                CategoryChip(
+                    name = stringResource(R.string.add_new_category_option),
+                    icon = "star.fill",
+                    selected = false,
+                    onClick = { creatingCategory = true },
+                )
             }
-            Spacer(Modifier.height(16.dp))
 
+            Spacer(Modifier.height(16.dp))
             Text(
-                text = stringResource(R.string.select_icon),
-                style = MaterialTheme.typography.titleSmall,
+                text = stringResource(
+                    if (isGym) R.string.add_picker_prompt_gym else R.string.add_picker_prompt_generic
+                ),
+                style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(Modifier.height(8.dp))
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(6),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                modifier = Modifier.height(140.dp),
-            ) {
-                items(ActivityCategory.availableIcons) { icon ->
-                    val isSelected = icon == selectedIcon
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .background(
-                                if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
-                                else MaterialTheme.colorScheme.surface,
-                                RoundedCornerShape(8.dp),
-                            )
-                            .clickable { selectedIcon = icon },
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
-                            imageVector = AppIcons.forKey(icon),
-                            contentDescription = null,
-                            tint = if (isSelected) MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(22.dp),
+
+            // Preset rows for the selected category + the user's own entries in it.
+            val presets = builtIn?.presetEntries.orEmpty()
+            val ownEntries = entries.filter { it.category == selectedCategoryId }
+            val presetNames = presets.map { context.getString(it.nameRes) }.toSet()
+            val rows = presets.map { preset ->
+                val name = context.getString(preset.nameRes)
+                PickerRow(
+                    key = "preset-$name",
+                    name = name,
+                    icon = preset.icon,
+                    existing = ownEntries.firstOrNull { it.name.equals(name, ignoreCase = true) },
+                    preset = preset.nameRes to preset.icon,
+                )
+            } + ownEntries.filterNot { presetNames.any { p -> p.equals(it.name, ignoreCase = true) } }
+                .map { entry ->
+                    PickerRow(key = "own-${entry.id}", name = entry.name, icon = entry.icon, existing = entry)
+                }
+
+            if (rows.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.add_picker_all_added),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 12.dp),
+                )
+            } else {
+                LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
+                    items(rows, key = { it.key }) { row ->
+                        PickerRowItem(
+                            row = row,
+                            onAdd = {
+                                val preset = row.preset
+                                if (preset != null && builtIn != null) {
+                                    onAddPreset(builtIn, preset.first, preset.second)
+                                }
+                            },
+                            onRemove = { row.existing?.let(onRemoveEntry) },
                         )
                     }
                 }
             }
 
-            errorMessage?.let { message ->
-                Spacer(Modifier.height(12.dp))
+            errorMessage?.let {
                 Text(
-                    text = message,
+                    text = it,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(top = 8.dp),
                 )
             }
 
-            Spacer(Modifier.height(24.dp))
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                TextButton(onClick = onDismiss, modifier = Modifier.weight(1f)) {
-                    Text(stringResource(R.string.cancel))
-                }
-                Button(
-                    onClick = { onSave(name, selectedCategoryId, selectedIcon) },
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Text(stringResource(R.string.save))
-                }
+            Spacer(Modifier.height(8.dp))
+            TextButton(onClick = { creatingOwn = true }) {
+                Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(20.dp))
+                Spacer(Modifier.size(8.dp))
+                Text(
+                    stringResource(
+                        if (isGym) R.string.add_create_custom_gym else R.string.add_create_custom_generic
+                    )
+                )
             }
+
+            Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.add_done))
+            }
+        }
+    }
+
+    if (creatingOwn) {
+        val defaultMetric = builtIn?.defaultMetric
+            ?: customCategories.firstOrNull { it.id == selectedCategoryId }?.defaultMetric
+            ?: MetricType.NONE
+        CreateOwnDialog(
+            isGym = isGym,
+            defaultMetric = defaultMetric,
+            defaultIcon = builtIn?.defaultIcon
+                ?: customCategories.firstOrNull { it.id == selectedCategoryId }?.icon
+                ?: ActivityCategory.CUSTOM.defaultIcon,
+            onAdd = { name, metric, icon ->
+                onAddCustom(name, selectedCategoryId, icon, metric)
+                creatingOwn = false
+            },
+            onDismiss = { creatingOwn = false },
+        )
+    }
+
+    if (creatingCategory) {
+        CreateCategoryDialog(
+            onAdd = { name, icon, metric ->
+                onCreateCategory(name, icon, metric)
+                creatingCategory = false
+            },
+            onDismiss = { creatingCategory = false },
+        )
+    }
+}
+
+private data class PickerRow(
+    val key: String,
+    val name: String,
+    val icon: String,
+    val existing: MuscleEntry?,
+    /** (nameRes, icon) when this row comes from a built-in preset. */
+    val preset: Pair<Int, String>? = null,
+)
+
+@Composable
+private fun PickerRowItem(row: PickerRow, onAdd: () -> Unit, onRemove: () -> Unit) {
+    val inList = row.existing != null
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { if (inList) onRemove() else onAdd() }
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = AppIcons.forKey(row.icon),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(Modifier.size(12.dp))
+        Text(row.name, style = MaterialTheme.typography.bodyLarge)
+        Spacer(Modifier.weight(1f))
+        if (inList) {
+            Text(
+                text = stringResource(R.string.add_in_your_list),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.size(8.dp))
+            Icon(
+                Icons.Filled.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp),
+            )
+        } else {
+            Icon(
+                Icons.Filled.Add,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryChip(name: String, icon: String, selected: Boolean, onClick: () -> Unit) {
+    val background = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent
+    val content = if (selected) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Row(
+        modifier = Modifier
+            .background(background, RoundedCornerShape(20.dp))
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(20.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = AppIcons.forKey(icon),
+            contentDescription = null,
+            tint = content,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.size(6.dp))
+        Text(name, style = MaterialTheme.typography.labelLarge, color = content)
+    }
+}
+
+/** Escape hatch for names outside the presets; category is inherited from the chip. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CreateOwnDialog(
+    isGym: Boolean,
+    defaultMetric: MetricType,
+    defaultIcon: String,
+    onAdd: (String, MetricType, String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var metric by remember { mutableStateOf(defaultMetric) }
+    var icon by remember { mutableStateOf(defaultIcon) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.imePadding(),
+        title = {
+            Text(
+                stringResource(
+                    if (isGym) R.string.add_create_custom_title_gym else R.string.add_create_custom_title
+                )
+            )
+        },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = {
+                        Text(
+                            stringResource(
+                                if (isGym) R.string.add_name_placeholder_gym
+                                else R.string.add_name_placeholder_generic
+                            )
+                        )
+                    },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                MetricDropdown(metric = metric, onMetricChange = { metric = it })
+                Spacer(Modifier.height(12.dp))
+                IconPickerRow(selected = icon, onSelect = { icon = it })
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onAdd(name, metric, icon) }, enabled = name.isNotBlank()) {
+                Text(stringResource(R.string.add_create_confirm))
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) } },
+    )
+}
+
+/** Create a category without leaving the add flow (same store as Settings). */
+@Composable
+private fun CreateCategoryDialog(
+    onAdd: (String, String, MetricType) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var icon by remember { mutableStateOf(ActivityCategory.CUSTOM.defaultIcon) }
+    var metric by remember { mutableStateOf(MetricType.NONE) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.imePadding(),
+        title = { Text(stringResource(R.string.custom_category_section_new)) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.custom_category_name_placeholder)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                MetricDropdown(metric = metric, onMetricChange = { metric = it })
+                Spacer(Modifier.height(12.dp))
+                IconPickerRow(selected = icon, onSelect = { icon = it })
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onAdd(name, icon, metric) }, enabled = name.isNotBlank()) {
+                Text(stringResource(R.string.custom_category_add))
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) } },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun MetricDropdown(metric: MetricType, onMetricChange: (MetricType) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+        OutlinedTextField(
+            value = stringResource(metric.displayNameRes),
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(stringResource(R.string.add_metric_question)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth(),
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            MetricType.entries.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(stringResource(option.displayNameRes)) },
+                    onClick = {
+                        onMetricChange(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+/** Compact horizontal icon picker (the full grid lives in Settings). */
+@Composable
+private fun IconPickerRow(selected: String, onSelect: (String) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ActivityCategory.availableIcons.forEach { key ->
+            val isSelected = key == selected
+            Icon(
+                imageVector = AppIcons.forKey(key),
+                contentDescription = null,
+                tint = if (isSelected) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                modifier = Modifier
+                    .background(
+                        if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
+                        RoundedCornerShape(8.dp),
+                    )
+                    .clickable { onSelect(key) }
+                    .padding(8.dp)
+                    .size(24.dp),
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/GroupDetailSheet.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/GroupDetailSheet.kt
@@ -1,0 +1,262 @@
+package com.zadkiel.musclecheck.ui.home
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.zadkiel.musclecheck.R
+import com.zadkiel.musclecheck.domain.model.Exercise
+import com.zadkiel.musclecheck.domain.model.MetricType
+import com.zadkiel.musclecheck.domain.model.MuscleEntry
+import com.zadkiel.musclecheck.domain.model.WeightUnit
+import com.zadkiel.musclecheck.ui.icons.AppIcons
+
+/**
+ * Opened by tapping a group's NAME (for groups whose metric logs something). Lists the
+ * group's exercises with their last values; tap one to edit, or add a new one.
+ *
+ * The weekly CHECK stays on the home row — coming in here is never required to mark the
+ * group trained. Logging an exercise here also marks the group trained today.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupDetailSheet(
+    entry: MuscleEntry,
+    groupMetric: MetricType,
+    weightUnit: WeightUnit,
+    onExerciseClick: (Exercise) -> Unit,
+    onAddExercise: (name: String, metric: MetricType, icon: String) -> Unit,
+    onDeleteExercise: (Exercise) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var adding by remember { mutableStateOf(false) }
+    var pendingDelete by remember { mutableStateOf<Exercise?>(null) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
+        ) {
+            Text(
+                text = entry.name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(16.dp))
+
+            if (entry.exercises.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.group_no_exercises, entry.name),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            } else {
+                // Capped so a long list doesn't push the "add" action off the sheet.
+                LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
+                    items(entry.exercises, key = { it.id }) { exercise ->
+                        ExerciseRow(
+                            exercise = exercise,
+                            weightUnit = weightUnit,
+                            onClick = { onExerciseClick(exercise) },
+                            onDelete = { pendingDelete = exercise },
+                        )
+                        HorizontalDivider()
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+            TextButton(onClick = { adding = true }) {
+                Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(20.dp))
+                Spacer(Modifier.size(8.dp))
+                Text(stringResource(R.string.group_add_exercise))
+            }
+        }
+    }
+
+    if (adding) {
+        AddExerciseToGroupDialog(
+            defaultMetric = if (groupMetric == MetricType.NONE) MetricType.STRENGTH else groupMetric,
+            defaultIcon = entry.icon,
+            onAdd = { name, metric, icon ->
+                onAddExercise(name, metric, icon)
+                adding = false
+            },
+            onDismiss = { adding = false },
+        )
+    }
+
+    pendingDelete?.let { exercise ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text(stringResource(R.string.delete_entry_title)) },
+            text = { Text(stringResource(R.string.delete_entry_message, exercise.name)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    onDeleteExercise(exercise)
+                    pendingDelete = null
+                }) { Text(stringResource(R.string.delete)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) { Text(stringResource(R.string.cancel)) }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ExerciseRow(
+    exercise: Exercise,
+    weightUnit: WeightUnit,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = AppIcons.forKey(exercise.icon),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(Modifier.size(12.dp))
+        Text(text = exercise.name, style = MaterialTheme.typography.bodyLarge)
+        Spacer(Modifier.weight(1f))
+        exercise.summary(weightUnit)?.let { summary ->
+            Text(
+                text = summary,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(onClick = onDelete) {
+            Icon(
+                Icons.Filled.Delete,
+                contentDescription = stringResource(R.string.delete),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        Icon(
+            Icons.Filled.ChevronRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}
+
+/**
+ * Create an exercise inside the current group. Metric/icon default to the group's; the
+ * name is the only required field.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddExerciseToGroupDialog(
+    defaultMetric: MetricType,
+    defaultIcon: String,
+    onAdd: (String, MetricType, String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var metric by remember { mutableStateOf(defaultMetric) }
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.imePadding(),
+        title = { Text(stringResource(R.string.group_add_exercise)) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.group_exercise_name_placeholder)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                ExposedDropdownMenuBox(
+                    expanded = menuExpanded,
+                    onExpandedChange = { menuExpanded = it },
+                ) {
+                    OutlinedTextField(
+                        value = stringResource(metric.displayNameRes),
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text(stringResource(R.string.add_metric_question)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = menuExpanded) },
+                        modifier = Modifier
+                            .menuAnchor(androidx.compose.material3.MenuAnchorType.PrimaryNotEditable)
+                            .fillMaxWidth(),
+                    )
+                    ExposedDropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                        MetricType.entries.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(stringResource(option.displayNameRes)) },
+                                onClick = {
+                                    metric = option
+                                    menuExpanded = false
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onAdd(name, metric, defaultIcon) },
+                enabled = name.isNotBlank(),
+            ) { Text(stringResource(R.string.add_create_confirm)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        },
+    )
+}

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/HomeScreen.kt
@@ -58,6 +58,13 @@ import com.zadkiel.musclecheck.domain.model.WeightUnit
 import com.zadkiel.musclecheck.ui.icons.AppIcons
 import com.zadkiel.musclecheck.ui.theme.LocalAccents
 import kotlin.math.roundToInt
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.zadkiel.musclecheck.domain.model.Exercise
+import com.zadkiel.musclecheck.domain.model.MetricType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -71,8 +78,12 @@ fun HomeScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val addError by viewModel.addError.collectAsStateWithLifecycle()
 
+    val lastAddCategory by viewModel.lastAddCategory.collectAsStateWithLifecycle()
+
     var showAddSheet by remember { mutableStateOf(false) }
     var sessionEntry by remember { mutableStateOf<MuscleEntry?>(null) }
+    var detailEntry by remember { mutableStateOf<MuscleEntry?>(null) }
+    var exerciseTarget by remember { mutableStateOf<Pair<MuscleEntry, Exercise>?>(null) }
     var entryToDelete by remember { mutableStateOf<MuscleEntry?>(null) }
 
     Scaffold(
@@ -84,10 +95,9 @@ fun HomeScreen(
                         Text(stringResource(R.string.navigation_history_button))
                     }
                 },
+                // No "+" here: adding lives in the FAB (bottom-right), which keeps the
+                // action reachable one-handed AND leaves room for the title.
                 actions = {
-                    IconButton(onClick = { showAddSheet = true }) {
-                        Icon(Icons.Filled.AddCircleOutline, contentDescription = stringResource(R.string.add_new_muscle_group))
-                    }
                     IconButton(onClick = onOpenSettings) {
                         Icon(Icons.Filled.Settings, contentDescription = stringResource(R.string.settings_title))
                     }
@@ -99,6 +109,14 @@ fun HomeScreen(
                     }
                 },
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showAddSheet = true }) {
+                Icon(
+                    Icons.Filled.Add,
+                    contentDescription = stringResource(R.string.add_new_muscle_group),
+                )
+            }
         },
     ) { padding ->
         Column(
@@ -114,7 +132,7 @@ fun HomeScreen(
             Spacer(Modifier.height(16.dp))
 
             if (state.loaded && state.isEmpty) {
-                EmptyState()
+                EmptyState(onAdd = { showAddSheet = true })
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     val showHeaders = state.groups.size > 1
@@ -126,12 +144,16 @@ fun HomeScreen(
                         }
                         items(count = group.entries.size, key = { group.entries[it].id }) { index ->
                             val entry = group.entries[index]
+                            val metric = entry.metricResolving(state.customCategories)
                             MuscleEntryRow(
                                 entry = entry,
-                                customCategories = state.customCategories,
+                                metric = metric,
                                 weightUnit = state.weightUnit,
                                 onToggle = { viewModel.toggleActivity(entry) },
-                                onOpenSession = { sessionEntry = entry },
+                                // Tapping the NAME opens the group's exercise list (the
+                                // detail layer). The check on the right is untouched —
+                                // marking the group trained never requires coming here.
+                                onOpenDetail = { if (metric.logsSomething) detailEntry = entry },
                                 onLongPress = { entryToDelete = entry },
                             )
                             if (index < group.entries.lastIndex) {
@@ -146,11 +168,15 @@ fun HomeScreen(
 
     if (showAddSheet) {
         AddEntrySheet(
+            entries = state.allEntries,
             customCategories = state.customCategories,
             errorMessage = addError,
-            onSave = { name, category, icon ->
-                viewModel.addEntry(name, category, icon) { showAddSheet = false }
-            },
+            initialCategoryId = lastAddCategory,
+            onCategorySelected = viewModel::rememberAddCategory,
+            onAddPreset = { category, nameRes, icon -> viewModel.addPresetEntry(category, nameRes, icon) },
+            onAddCustom = { name, category, icon, metric -> viewModel.addEntry(name, category, icon, metric) },
+            onRemoveEntry = { viewModel.deleteEntry(it) },
+            onCreateCategory = { name, icon, metric -> viewModel.createCategory(name, icon, metric) },
             onDismiss = {
                 viewModel.clearAddError()
                 showAddSheet = false
@@ -158,12 +184,38 @@ fun HomeScreen(
         )
     }
 
+    detailEntry?.let { entry ->
+        // Re-read from state so the sheet reflects edits made while it is open.
+        val fresh = state.allEntries.firstOrNull { it.id == entry.id } ?: entry
+        GroupDetailSheet(
+            entry = fresh,
+            groupMetric = fresh.metricResolving(state.customCategories),
+            weightUnit = state.weightUnit,
+            onExerciseClick = { exerciseTarget = fresh to it },
+            onAddExercise = { name, metric, icon -> viewModel.addExercise(fresh, name, metric, icon) },
+            onDeleteExercise = { viewModel.deleteExercise(it) },
+            onDismiss = { detailEntry = null },
+        )
+    }
+
+    exerciseTarget?.let { (entry, exercise) ->
+        SessionLogSheet(
+            target = SessionLogTarget.of(exercise),
+            weightUnit = state.weightUnit,
+            onSave = { input ->
+                viewModel.logExercise(entry, exercise, input)
+                exerciseTarget = null
+            },
+            onDismiss = { exerciseTarget = null },
+        )
+    }
+
     sessionEntry?.let { entry ->
         SessionLogSheet(
-            entry = entry,
+            target = SessionLogTarget.of(entry, entry.metricResolving(state.customCategories)),
             weightUnit = state.weightUnit,
-            onSave = { weightKg, sets, reps ->
-                viewModel.saveSession(entry, weightKg, sets, reps)
+            onSave = { input ->
+                viewModel.saveSession(entry, input)
                 sessionEntry = null
             },
             onDismiss = { sessionEntry = null },
@@ -295,23 +347,20 @@ private fun CategoryHeader(categoryRaw: String, customCategories: List<CustomCat
 @Composable
 private fun MuscleEntryRow(
     entry: MuscleEntry,
-    customCategories: List<CustomCategory>,
+    metric: MetricType,
     weightUnit: WeightUnit,
     onToggle: () -> Unit,
-    onOpenSession: () -> Unit,
+    onOpenDetail: () -> Unit,
     onLongPress: () -> Unit,
 ) {
-    val context = LocalContext.current
     val accents = LocalAccents.current
-    val tracksWeight = remember(entry.category, customCategories) {
-        CategoryResolver.resolve(entry.category, customCategories, context).tracksWeight
-    }
+    val summary = remember(entry, weightUnit) { entry.summary(weightUnit) }
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .combinedClickable(
-                onClick = { if (tracksWeight) onOpenSession() },
+                onClick = onOpenDetail,
                 onLongClick = onLongPress,
             )
             .padding(horizontal = 16.dp, vertical = 10.dp),
@@ -334,11 +383,21 @@ private fun MuscleEntryRow(
         Spacer(Modifier.width(12.dp))
         Text(entry.name, style = MaterialTheme.typography.bodyLarge)
 
-        if (tracksWeight) {
-            entry.lastWeightKg?.let { kg ->
+        // "80 kg" for a bare group, "3 ejercicios · Peso muerto 100 kg" once it has
+        // exercises — assembled here because the count needs a plural resource.
+        summary?.let { s ->
+            val label = when {
+                s.exerciseCount > 0 && s.recentName != null && s.recentValue != null ->
+                    "${pluralStringResource(R.plurals.exercise_count, s.exerciseCount, s.exerciseCount)} · " +
+                        "${s.recentName} ${s.recentValue}"
+                s.exerciseCount > 0 ->
+                    pluralStringResource(R.plurals.exercise_count, s.exerciseCount, s.exerciseCount)
+                else -> s.ownLabel
+            }
+            if (label != null) {
                 Spacer(Modifier.width(8.dp))
                 Text(
-                    text = "${weightUnit.displayValue(kg).roundToInt()} ${weightUnit.displayLabel}",
+                    text = label,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -360,17 +419,26 @@ private fun MuscleEntryRow(
 // MARK: - Empty state
 
 @Composable
-private fun EmptyState() {
-    Box(
+private fun EmptyState(onAdd: () -> Unit) {
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(32.dp),
-        contentAlignment = Alignment.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = stringResource(R.string.empty_state_message),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
         )
+        Spacer(Modifier.height(16.dp))
+        // A real CTA, not just a pointer at the FAB: this is the screen a first-timer
+        // lands on, and "where do I add things" was the top confusion report.
+        Button(onClick = onAdd) {
+            Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.size(8.dp))
+            Text(stringResource(R.string.empty_state_add_button))
+        }
     }
 }

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/HomeViewModel.kt
@@ -6,9 +6,13 @@ import com.zadkiel.musclecheck.data.prefs.UserPreferencesRepository
 import com.zadkiel.musclecheck.data.repository.MuscleRepository
 import com.zadkiel.musclecheck.domain.AppWeek
 import com.zadkiel.musclecheck.domain.StreakCalculator
+import com.zadkiel.musclecheck.domain.model.ActivityCategory
 import com.zadkiel.musclecheck.domain.model.CategoryResolver
 import com.zadkiel.musclecheck.domain.model.CustomCategory
+import com.zadkiel.musclecheck.domain.model.Exercise
+import com.zadkiel.musclecheck.domain.model.MetricType
 import com.zadkiel.musclecheck.domain.model.MuscleEntry
+import com.zadkiel.musclecheck.domain.model.SessionInput
 import com.zadkiel.musclecheck.domain.model.WeightUnit
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,6 +28,7 @@ data class CategoryGroup(val category: String, val entries: List<MuscleEntry>)
 
 data class HomeUiState(
     val groups: List<CategoryGroup> = emptyList(),
+    val allEntries: List<MuscleEntry> = emptyList(),
     val customCategories: List<CustomCategory> = emptyList(),
     val weightUnit: WeightUnit = WeightUnit.KG,
     val currentStreak: Int = 0,
@@ -37,14 +42,21 @@ data class HomeUiState(
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val repository: MuscleRepository,
-    prefs: UserPreferencesRepository,
+    private val prefs: UserPreferencesRepository,
 ) : ViewModel() {
 
     /** Error shown inside the add sheet (duplicate/empty name). */
     val addError = MutableStateFlow<String?>(null)
 
+    /** Category the add sheet opens on — the last one used. */
+    val lastAddCategory = MutableStateFlow(ActivityCategory.GYM.id)
+
     init {
-        viewModelScope.launch { repository.resetChecksIfNewWeek() }
+        viewModelScope.launch {
+            repository.resetChecksIfNewWeek()
+            // Resolve + persist the metric of entries created before metrics existed.
+            repository.backfillMetricTypes()
+        }
     }
 
     val uiState: StateFlow<HomeUiState> = combine(
@@ -65,6 +77,7 @@ class HomeViewModel @Inject constructor(
 
         HomeUiState(
             groups = groups,
+            allEntries = currentWeekEntries,
             customCategories = custom,
             weightUnit = unit,
             currentStreak = StreakCalculator.currentStreak(entries),
@@ -77,21 +90,63 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch { repository.toggleActivity(entry) }
     }
 
-    fun saveSession(entry: MuscleEntry, weightKg: Double?, sets: Int?, reps: Int?) {
-        viewModelScope.launch { repository.saveTodaySession(entry.id, weightKg, sets, reps) }
+    /** Group-level session (groups with no exercises yet). */
+    fun saveSession(entry: MuscleEntry, input: SessionInput) {
+        viewModelScope.launch { repository.saveTodaySession(entry.id, input) }
     }
 
     fun deleteEntry(entry: MuscleEntry) {
         viewModelScope.launch { repository.deleteEntry(entry.id) }
     }
 
-    /** Returns via callback so the sheet can close only on success. */
-    fun addEntry(name: String, category: String, icon: String, onSuccess: () -> Unit) {
+    // MARK: - Exercises
+
+    fun addExercise(entry: MuscleEntry, name: String, metric: MetricType, icon: String) {
         viewModelScope.launch {
             try {
-                repository.addEntry(name, category, icon)
+                repository.addExercise(entry.id, name, metric, icon)
                 addError.value = null
-                onSuccess()
+            } catch (e: Exception) {
+                addError.value = repository.errorMessage(e)
+            }
+        }
+    }
+
+    fun deleteExercise(exercise: Exercise) {
+        viewModelScope.launch { repository.deleteExercise(exercise.id) }
+    }
+
+    /** Saves an exercise's values; the repository also marks the group trained today. */
+    fun logExercise(entry: MuscleEntry, exercise: Exercise, input: SessionInput) {
+        viewModelScope.launch { repository.logExercise(entry.id, exercise.id, input) }
+    }
+
+    // MARK: - Add flow
+
+    fun rememberAddCategory(categoryId: String) {
+        lastAddCategory.value = categoryId
+    }
+
+    fun addPresetEntry(category: ActivityCategory, nameRes: Int, icon: String) {
+        viewModelScope.launch { repository.addPresetEntry(category, nameRes, icon) }
+    }
+
+    fun addEntry(name: String, category: String, icon: String, metric: MetricType) {
+        viewModelScope.launch {
+            try {
+                repository.addEntry(name, category, icon, metric)
+                addError.value = null
+            } catch (e: Exception) {
+                addError.value = repository.errorMessage(e)
+            }
+        }
+    }
+
+    fun createCategory(name: String, icon: String, metric: MetricType) {
+        viewModelScope.launch {
+            try {
+                repository.addCustomCategory(name, icon, metric)
+                addError.value = null
             } catch (e: Exception) {
                 addError.value = repository.errorMessage(e)
             }

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/SessionLogSheet.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/home/SessionLogSheet.kt
@@ -6,10 +6,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
@@ -19,6 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
@@ -40,87 +44,147 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.zadkiel.musclecheck.R
+import com.zadkiel.musclecheck.domain.model.Exercise
+import com.zadkiel.musclecheck.domain.model.MetricType
 import com.zadkiel.musclecheck.domain.model.MuscleEntry
+import com.zadkiel.musclecheck.domain.model.SessionInput
 import com.zadkiel.musclecheck.domain.model.WeightUnit
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.math.roundToInt
 
 /**
- * "Registro" — session editor. Opens calm (no keyboard): the weight is a big tappable
- * number and sets/reps are steppers. Weight is converted to kg at this boundary.
+ * What [SessionLogSheet] edits — decoupled from MuscleEntry so it can drive an exercise
+ * (the detail layer) or a group. Prefill values are pre-resolved by the caller; for
+ * distanceDuration, distance + duration come from the SAME session so a distance from
+ * one day and a time from another are never paired as if done together.
+ */
+data class SessionLogTarget(
+    val title: String,
+    val metric: MetricType,
+    val lastWeightKg: Double? = null,
+    val lastSets: Int? = null,
+    val lastReps: Int? = null,
+    val lastDurationSeconds: Int? = null,
+    val lastDistanceMeters: Double? = null,
+    val lastTrained: LocalDate? = null,
+) {
+    companion object {
+        fun of(exercise: Exercise): SessionLogTarget {
+            val cardio = exercise.lastDistanceDurationSession
+            return SessionLogTarget(
+                title = exercise.name,
+                metric = exercise.metric,
+                lastWeightKg = exercise.lastWeightKg,
+                lastSets = exercise.lastSets,
+                lastReps = exercise.lastReps,
+                lastDurationSeconds = if (exercise.metric == MetricType.DISTANCE_DURATION) {
+                    cardio?.durationSeconds
+                } else {
+                    exercise.lastDurationSeconds
+                },
+                lastDistanceMeters = cardio?.distanceMeters,
+                lastTrained = exercise.lastTrainedDate,
+            )
+        }
+
+        fun of(entry: MuscleEntry, metric: MetricType): SessionLogTarget {
+            val cardio = entry.sessions
+                .filter { it.distanceMeters != null || it.durationSeconds != null }
+                .maxByOrNull { it.date }
+            return SessionLogTarget(
+                title = entry.name,
+                metric = metric,
+                lastWeightKg = entry.lastWeightKg,
+                lastSets = entry.lastSets,
+                lastReps = entry.lastReps,
+                lastDurationSeconds = cardio?.durationSeconds,
+                lastDistanceMeters = cardio?.distanceMeters,
+                lastTrained = entry.lastTrainedDate,
+            )
+        }
+    }
+}
+
+/**
+ * "Registro" — session editor driven by the target's [MetricType]. Opens calm (no
+ * keyboard): the main value is a big tappable number. Strength shows weight + sets/reps
+ * steppers; duration shows minutes; distanceDuration shows km with minutes below.
+ * Weight is converted to kg at this boundary.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SessionLogSheet(
-    entry: MuscleEntry,
+    target: SessionLogTarget,
     weightUnit: WeightUnit,
-    onSave: (weightKg: Double?, sets: Int?, reps: Int?) -> Unit,
+    onSave: (SessionInput) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    // Prefill so the user can consult/edit what they last did.
-    var weightText by remember(entry.id) {
-        mutableStateOf(entry.lastWeightKg?.let { weightUnit.displayValue(it).roundToInt().toString() } ?: "")
+    var weightText by remember(target.title) {
+        mutableStateOf(target.lastWeightKg?.let { weightUnit.displayValue(it).roundToInt().toString() } ?: "")
     }
-    var sets by remember(entry.id) { mutableIntStateOf(entry.lastSets ?: 0) }
-    var reps by remember(entry.id) { mutableIntStateOf(entry.lastReps ?: 0) }
+    var sets by remember(target.title) { mutableIntStateOf(target.lastSets ?: 0) }
+    var reps by remember(target.title) { mutableIntStateOf(target.lastReps ?: 0) }
+    var minutesText by remember(target.title) {
+        mutableStateOf(target.lastDurationSeconds?.let { (it / 60).toString() } ?: "")
+    }
+    var kmText by remember(target.title) {
+        mutableStateOf(target.lastDistanceMeters?.let { String.format("%.1f", it / 1000) } ?: "")
+    }
 
     val parsedWeight = weightText.replace(',', '.').toDoubleOrNull()
-    val isValid = (parsedWeight ?: 0.0) > 0.0
+    val parsedMinutes = minutesText.toIntOrNull()
+    val parsedKm = kmText.replace(',', '.').toDoubleOrNull()
+
+    val isValid = when (target.metric) {
+        MetricType.NONE -> false // unreachable: rows with no metric don't open the log
+        MetricType.STRENGTH -> (parsedWeight ?: 0.0) > 0.0
+        MetricType.DURATION -> (parsedMinutes ?: 0) > 0
+        // A runner may log only one of the two.
+        MetricType.DISTANCE_DURATION -> (parsedKm ?: 0.0) > 0.0 || (parsedMinutes ?: 0) > 0
+    }
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                // imePadding + scroll: without them the keyboard covers Save and the
+                // sheet becomes a dead end once you type a value.
+                .imePadding()
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp)
                 .padding(bottom = 32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = entry.name,
+                text = target.title,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
             Spacer(Modifier.height(24.dp))
 
-            // Weight hero — the value IS the display; tap it to type.
-            Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                TextField(
+            when (target.metric) {
+                MetricType.STRENGTH -> HeroValueField(
                     value = weightText,
-                    onValueChange = { new -> weightText = new.filter { it.isDigit() || it == '.' || it == ',' } },
-                    placeholder = {
-                        Text(
-                            "0",
-                            fontSize = 56.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    },
-                    textStyle = TextStyle(
-                        fontSize = 56.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        textAlign = TextAlign.Center,
-                    ),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    singleLine = true,
-                    colors = TextFieldDefaults.colors(
-                        focusedContainerColor = Color.Transparent,
-                        unfocusedContainerColor = Color.Transparent,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                    ),
-                    modifier = Modifier.width(180.dp),
+                    onValueChange = { weightText = it },
+                    unitLabel = weightUnit.displayLabel,
                 )
-                Text(
-                    text = weightUnit.displayLabel,
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(bottom = 16.dp),
+                MetricType.DURATION -> HeroValueField(
+                    value = minutesText,
+                    onValueChange = { minutesText = it },
+                    unitLabel = stringResource(R.string.session_unit_min),
+                    decimals = false,
                 )
+                MetricType.DISTANCE_DURATION -> HeroValueField(
+                    value = kmText,
+                    onValueChange = { kmText = it },
+                    unitLabel = stringResource(R.string.session_unit_km),
+                )
+                MetricType.NONE -> Unit
             }
 
-            entry.lastTrainedDate?.let { last ->
+            target.lastTrained?.let { last ->
                 val formatted = remember(last) {
                     last.format(DateTimeFormatter.ofPattern("EEE d MMM", Locale.getDefault()))
                 }
@@ -133,31 +197,60 @@ fun SessionLogSheet(
 
             Spacer(Modifier.height(28.dp))
 
-            // Sets / Reps — steppers, no keyboard.
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                StepperColumn(
-                    title = stringResource(R.string.session_field_sets),
-                    value = sets,
-                    onDecrement = { if (sets > 0) sets-- },
-                    onIncrement = { sets++ },
-                    modifier = Modifier.weight(1f),
+            when (target.metric) {
+                MetricType.STRENGTH -> Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    StepperColumn(
+                        title = stringResource(R.string.session_field_sets),
+                        value = sets,
+                        onDecrement = { if (sets > 0) sets-- },
+                        onIncrement = { sets++ },
+                        modifier = Modifier.weight(1f),
+                    )
+                    StepperColumn(
+                        title = stringResource(R.string.session_field_reps),
+                        value = reps,
+                        onDecrement = { if (reps > 0) reps-- },
+                        onIncrement = { reps++ },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                MetricType.DISTANCE_DURATION -> OutlinedTextField(
+                    value = minutesText,
+                    onValueChange = { new -> minutesText = new.filter { it.isDigit() } },
+                    label = { Text(stringResource(R.string.session_field_duration)) },
+                    suffix = { Text(stringResource(R.string.session_unit_min)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
                 )
-                StepperColumn(
-                    title = stringResource(R.string.session_field_reps),
-                    value = reps,
-                    onDecrement = { if (reps > 0) reps-- },
-                    onIncrement = { reps++ },
-                    modifier = Modifier.weight(1f),
-                )
+                else -> Unit
             }
 
             Spacer(Modifier.height(32.dp))
 
             Button(
                 onClick = {
-                    val kg = parsedWeight?.let { weightUnit.toKg(it.roundToInt().toDouble()) }
-                    // 0 means "not recorded" → store as null to keep the data clean.
-                    onSave(kg, sets.takeIf { it > 0 }, reps.takeIf { it > 0 })
+                    onSave(
+                        when (target.metric) {
+                            MetricType.STRENGTH -> SessionInput(
+                                // 0 means "not recorded" → store null to keep the data clean.
+                                weightKg = parsedWeight?.let { weightUnit.toKg(it.roundToInt().toDouble()) },
+                                sets = sets.takeIf { it > 0 },
+                                reps = reps.takeIf { it > 0 },
+                            )
+                            MetricType.DURATION -> SessionInput(
+                                durationSeconds = parsedMinutes?.takeIf { it > 0 }?.times(60),
+                            )
+                            MetricType.DISTANCE_DURATION -> SessionInput(
+                                durationSeconds = parsedMinutes?.takeIf { it > 0 }?.times(60),
+                                distanceMeters = parsedKm?.takeIf { it > 0.0 }?.times(1000),
+                            )
+                            MetricType.NONE -> SessionInput()
+                        }
+                    )
                 },
                 enabled = isValid,
                 modifier = Modifier.fillMaxWidth(),
@@ -168,6 +261,53 @@ fun SessionLogSheet(
                 Text(stringResource(R.string.cancel))
             }
         }
+    }
+}
+
+/** The big tappable number that is both the display and the input. */
+@Composable
+private fun HeroValueField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    unitLabel: String,
+    decimals: Boolean = true,
+) {
+    Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        TextField(
+            value = value,
+            onValueChange = { new ->
+                onValueChange(new.filter { it.isDigit() || (decimals && (it == '.' || it == ',')) })
+            },
+            placeholder = {
+                Text(
+                    "0",
+                    fontSize = 56.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            textStyle = TextStyle(
+                fontSize = 56.sp,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+            ),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            singleLine = true,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+            ),
+            modifier = Modifier.width(180.dp),
+        )
+        Text(
+            text = unitLabel,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
     }
 }
 

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/pro/PaywallScreen.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/pro/PaywallScreen.kt
@@ -51,11 +51,12 @@ import com.zadkiel.musclecheck.data.pro.ProPackage
 /** A Free-vs-Pro feature row. */
 private data class CompareRow(val labelRes: Int, val free: Boolean)
 
-// Reflects what the app actually gates today: checklist, AI coach, history,
-// stats and notifications ship free; only progress photos are Pro.
+// Reflects what the app actually SHIPS on Android today: checklist, history, stats and
+// notifications are free; only progress photos are Pro. The AI coach row is deliberately
+// absent — that feature is iOS-only (Apple Intelligence), and listing it here would
+// advertise something this build cannot deliver.
 private val compareRows = listOf(
     CompareRow(R.string.paywall_compare_checklist, free = true),
-    CompareRow(R.string.paywall_compare_ai, free = true),
     CompareRow(R.string.paywall_compare_history, free = true),
     CompareRow(R.string.paywall_compare_stats, free = true),
     CompareRow(R.string.paywall_compare_notifications, free = true),

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/settings/ManageCategoriesScreen.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/settings/ManageCategoriesScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -48,6 +47,8 @@ import com.zadkiel.musclecheck.R
 import com.zadkiel.musclecheck.data.repository.MuscleRepository
 import com.zadkiel.musclecheck.domain.model.ActivityCategory
 import com.zadkiel.musclecheck.domain.model.CustomCategory
+import com.zadkiel.musclecheck.domain.model.MetricType
+import com.zadkiel.musclecheck.ui.home.MetricDropdown
 import com.zadkiel.musclecheck.ui.icons.AppIcons
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -67,10 +68,10 @@ class ManageCategoriesViewModel @Inject constructor(
 
     val error = MutableStateFlow<String?>(null)
 
-    fun add(name: String, icon: String, tracksWeight: Boolean, onSuccess: () -> Unit) {
+    fun add(name: String, icon: String, defaultMetric: MetricType, onSuccess: () -> Unit) {
         viewModelScope.launch {
             try {
-                repository.addCustomCategory(name, icon, tracksWeight)
+                repository.addCustomCategory(name, icon, defaultMetric)
                 error.value = null
                 onSuccess()
             } catch (e: Exception) {
@@ -95,7 +96,9 @@ fun ManageCategoriesScreen(
 
     var name by remember { mutableStateOf("") }
     var selectedIcon by remember { mutableStateOf("star.fill") }
-    var tracksWeight by remember { mutableStateOf(false) }
+    // What entries in this category log by default — supersedes the old
+    // "tracks weight" boolean now that each exercise carries its own metric.
+    var defaultMetric by remember { mutableStateOf(MetricType.NONE) }
 
     Scaffold(
         topBar = {
@@ -158,10 +161,12 @@ fun ManageCategoriesScreen(
                         }
                     }
 
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(stringResource(R.string.custom_category_tracks_weight), modifier = Modifier.weight(1f))
-                        Switch(checked = tracksWeight, onCheckedChange = { tracksWeight = it })
-                    }
+                    Text(
+                        text = stringResource(R.string.custom_category_default_metric),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    MetricDropdown(metric = defaultMetric, onMetricChange = { defaultMetric = it })
 
                     error?.let { message ->
                         Text(
@@ -173,9 +178,9 @@ fun ManageCategoriesScreen(
 
                     Button(
                         onClick = {
-                            viewModel.add(name, selectedIcon, tracksWeight) {
+                            viewModel.add(name, selectedIcon, defaultMetric) {
                                 name = ""
-                                tracksWeight = false
+                                defaultMetric = MetricType.NONE
                                 selectedIcon = "star.fill"
                             }
                         },

--- a/android/app/src/main/java/com/zadkiel/musclecheck/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/zadkiel/musclecheck/ui/settings/SettingsScreen.kt
@@ -313,6 +313,14 @@ fun SettingsScreen(
                                 selected = state.weightUnit == unit,
                                 onClick = { viewModel.setWeightUnit(unit) },
                                 shape = SegmentedButtonDefaults.itemShape(index = index, count = WeightUnit.entries.size),
+                                // Default M3 colors paint the active segment with the
+                                // secondary container (purple) — the only off-palette
+                                // element in an otherwise blue app.
+                                colors = SegmentedButtonDefaults.colors(
+                                    activeContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                                    activeContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    activeBorderColor = MaterialTheme.colorScheme.primary,
+                                ),
                             ) {
                                 Text(unit.displayLabel)
                             }

--- a/android/app/src/main/res/drawable/widget_preview_background.xml
+++ b/android/app/src/main/res/drawable/widget_preview_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="#F2F1F8" />
+</shape>

--- a/android/app/src/main/res/layout/widget_preview.xml
+++ b/android/app/src/main/res/layout/widget_preview.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Static preview shown in the launcher's widget picker. Without it the picker falls
+  back to the app icon, which tells the user nothing about what the widget shows.
+  Glance renders the real thing at runtime; this only has to look like it.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:background="@drawable/widget_preview_background">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="🔥 3"
+            android:textColor="#E8710A"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="🏆 5"
+            android:textSize="14sp" />
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="✓ Chest"
+        android:textSize="13sp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="✓ Back"
+        android:textSize="13sp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="○ Legs"
+        android:textSize="13sp" />
+</LinearLayout>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -51,7 +51,7 @@
     <!-- Home -->
     <string name="navigation_history_button">Historial</string>
     <string name="add_new_muscle_group">Agregar nuevo grupo muscular</string>
-    <string name="empty_state_message">Añade tus grupos musculares tocando el botón [+] en la esquina superior derecha.</string>
+    <string name="empty_state_message">Aún no hay nada esta semana. Agrega tu primera actividad.</string>
     <string name="streak_current">semanas seguidas</string>
     <string name="streak_max">Mejor</string>
     <string name="delete_entry_title">¿Eliminar actividad?</string>
@@ -173,4 +173,42 @@
     <string name="paywall_price_lifetime">$29.99</string>
     <string name="paywall_subscribe">Continuar</string>
     <string name="paywall_restore">Restaurar compras</string>
+
+    <!-- Feature 18/19: per-exercise metrics, unified add, exercises in group -->
+    <string name="metric_type_none">Solo check</string>
+    <string name="metric_type_strength">Peso y reps</string>
+    <string name="metric_type_duration">Tiempo</string>
+    <string name="metric_type_distance_duration">Distancia y tiempo</string>
+    <string name="session_field_duration">Duración</string>
+    <string name="session_field_distance">Distancia</string>
+    <string name="session_unit_min">min</string>
+    <string name="session_unit_km">km</string>
+    <string name="group_no_exercises">Todavía no agregaste ejercicios a %1$s.</string>
+    <string name="group_add_exercise">Agregar ejercicio</string>
+    <string name="group_exercise_name_placeholder">Peso muerto</string>
+    <string name="add_metric_question">¿Qué quieres registrar?</string>
+    <string name="add_new_category_option">Nueva categoría…</string>
+    <string name="add_sheet_title">Agregar a tu lista</string>
+    <string name="add_done">Listo</string>
+    <string name="add_in_your_list">En tu lista</string>
+    <string name="add_picker_all_added">Todo esto ya está en tu lista ✓ Prueba otra categoría o crea algo propio.</string>
+    <string name="add_picker_prompt_gym">¿Qué grupos musculares entrenas?</string>
+    <string name="add_picker_prompt_generic">¿Qué actividades haces?</string>
+    <string name="add_create_custom_title">Nueva actividad</string>
+    <string name="add_create_custom_title_gym">Nuevo grupo</string>
+    <string name="add_create_custom_gym">Crea el tuyo…</string>
+    <string name="add_create_custom_generic">Crea la tuya…</string>
+    <string name="add_create_confirm">Agregar</string>
+    <string name="add_name_placeholder_gym">Glúteos</string>
+    <string name="add_name_placeholder_generic">Escalada</string>
+    <string name="custom_category_default_metric">Registro por defecto</string>
+    <string name="empty_state_add_button">Agregar actividad</string>
+    <plurals name="exercise_count">
+        <item quantity="one">%1$d ejercicio</item>
+        <item quantity="other">%1$d ejercicios</item>
+    </plurals>
+    <plurals name="history_month_summary_plural">
+        <item quantity="one">%1$d día entrenado en %2$s</item>
+        <item quantity="other">%1$d días entrenados en %2$s</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -43,7 +43,7 @@
     <string name="stretching_full">Étirement complet</string>
     <string name="navigation_history_button">Historique</string>
     <string name="add_new_muscle_group">Ajouter un groupe musculaire</string>
-    <string name="empty_state_message">Ajoute tes groupes musculaires en touchant le bouton [+] en haut à droite.</string>
+    <string name="empty_state_message">Rien cette semaine pour l\'instant. Ajoute ta première activité.</string>
     <string name="streak_current">semaines d\'affilée</string>
     <string name="streak_max">Record</string>
     <string name="delete_entry_title">Supprimer l\'activité ?</string>
@@ -145,4 +145,42 @@
     <string name="paywall_price_lifetime">$29.99</string>
     <string name="paywall_subscribe">Continuer</string>
     <string name="paywall_restore">Restaurer les achats</string>
+
+    <!-- Feature 18/19: per-exercise metrics, unified add, exercises in group -->
+    <string name="metric_type_none">Coche uniquement</string>
+    <string name="metric_type_strength">Poids et réps</string>
+    <string name="metric_type_duration">Durée</string>
+    <string name="metric_type_distance_duration">Distance et durée</string>
+    <string name="session_field_duration">Durée</string>
+    <string name="session_field_distance">Distance</string>
+    <string name="session_unit_min">min</string>
+    <string name="session_unit_km">km</string>
+    <string name="group_no_exercises">Aucun exercice dans %1$s pour l\'instant.</string>
+    <string name="group_add_exercise">Ajouter un exercice</string>
+    <string name="group_exercise_name_placeholder">Soulevé de terre</string>
+    <string name="add_metric_question">Que veux-tu noter ?</string>
+    <string name="add_new_category_option">Nouvelle catégorie…</string>
+    <string name="add_sheet_title">Ajouter à ta liste</string>
+    <string name="add_done">OK</string>
+    <string name="add_in_your_list">Dans ta liste</string>
+    <string name="add_picker_all_added">Tout est déjà dans ta liste ✓ Essaie une autre catégorie ou crée le tien.</string>
+    <string name="add_picker_prompt_gym">Quels groupes musculaires entraînes-tu ?</string>
+    <string name="add_picker_prompt_generic">Quelles activités pratiques-tu ?</string>
+    <string name="add_create_custom_title">Nouvelle activité</string>
+    <string name="add_create_custom_title_gym">Nouveau groupe</string>
+    <string name="add_create_custom_gym">Crée le tien…</string>
+    <string name="add_create_custom_generic">Crée la tienne…</string>
+    <string name="add_create_confirm">Ajouter</string>
+    <string name="add_name_placeholder_gym">Fessiers</string>
+    <string name="add_name_placeholder_generic">Escalade</string>
+    <string name="custom_category_default_metric">Suivi par défaut</string>
+    <string name="empty_state_add_button">Ajouter une activité</string>
+    <plurals name="exercise_count">
+        <item quantity="one">%1$d exercice</item>
+        <item quantity="other">%1$d exercices</item>
+    </plurals>
+    <plurals name="history_month_summary_plural">
+        <item quantity="one">%1$d jour d\'entraînement en %2$s</item>
+        <item quantity="other">%1$d jours d\'entraînement en %2$s</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -43,7 +43,7 @@
     <string name="stretching_full">Stretching completo</string>
     <string name="navigation_history_button">Cronologia</string>
     <string name="add_new_muscle_group">Aggiungi gruppo muscolare</string>
-    <string name="empty_state_message">Aggiungi i tuoi gruppi muscolari toccando il pulsante [+] in alto a destra.</string>
+    <string name="empty_state_message">Ancora niente questa settimana. Aggiungi la tua prima attività.</string>
     <string name="streak_current">settimane di fila</string>
     <string name="streak_max">Migliore</string>
     <string name="delete_entry_title">Eliminare l\'attività?</string>
@@ -145,4 +145,42 @@
     <string name="paywall_price_lifetime">$29.99</string>
     <string name="paywall_subscribe">Continua</string>
     <string name="paywall_restore">Ripristina acquisti</string>
+
+    <!-- Feature 18/19: per-exercise metrics, unified add, exercises in group -->
+    <string name="metric_type_none">Solo spunta</string>
+    <string name="metric_type_strength">Peso e ripetizioni</string>
+    <string name="metric_type_duration">Tempo</string>
+    <string name="metric_type_distance_duration">Distanza e tempo</string>
+    <string name="session_field_duration">Durata</string>
+    <string name="session_field_distance">Distanza</string>
+    <string name="session_unit_min">min</string>
+    <string name="session_unit_km">km</string>
+    <string name="group_no_exercises">Ancora nessun esercizio in %1$s.</string>
+    <string name="group_add_exercise">Aggiungi esercizio</string>
+    <string name="group_exercise_name_placeholder">Stacco da terra</string>
+    <string name="add_metric_question">Cosa vuoi registrare?</string>
+    <string name="add_new_category_option">Nuova categoria…</string>
+    <string name="add_sheet_title">Aggiungi alla tua lista</string>
+    <string name="add_done">Fatto</string>
+    <string name="add_in_your_list">Nella tua lista</string>
+    <string name="add_picker_all_added">È già tutto nella tua lista ✓ Prova un\'altra categoria o crea qualcosa di tuo.</string>
+    <string name="add_picker_prompt_gym">Quali gruppi muscolari alleni?</string>
+    <string name="add_picker_prompt_generic">Quali attività pratichi?</string>
+    <string name="add_create_custom_title">Nuova attività</string>
+    <string name="add_create_custom_title_gym">Nuovo gruppo</string>
+    <string name="add_create_custom_gym">Crea il tuo…</string>
+    <string name="add_create_custom_generic">Crea la tua…</string>
+    <string name="add_create_confirm">Aggiungi</string>
+    <string name="add_name_placeholder_gym">Glutei</string>
+    <string name="add_name_placeholder_generic">Arrampicata</string>
+    <string name="custom_category_default_metric">Tracciamento predefinito</string>
+    <string name="empty_state_add_button">Aggiungi attività</string>
+    <plurals name="exercise_count">
+        <item quantity="one">%1$d esercizio</item>
+        <item quantity="other">%1$d esercizi</item>
+    </plurals>
+    <plurals name="history_month_summary_plural">
+        <item quantity="one">%1$d giorno di allenamento a %2$s</item>
+        <item quantity="other">%1$d giorni di allenamento a %2$s</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <!-- Home -->
     <string name="navigation_history_button">History</string>
     <string name="add_new_muscle_group">Add new muscle group</string>
-    <string name="empty_state_message">Add your muscle groups by tapping the [+] button in the top right corner.</string>
+    <string name="empty_state_message">Nothing this week yet. Add your first activity.</string>
     <string name="streak_current">weeks in a row</string>
     <string name="streak_max">Best</string>
     <string name="delete_entry_title">Delete activity?</string>
@@ -173,4 +173,42 @@
     <string name="paywall_price_lifetime">$29.99</string>
     <string name="paywall_subscribe">Continue</string>
     <string name="paywall_restore">Restore purchases</string>
+
+    <!-- Feature 18/19: per-exercise metrics, unified add, exercises in group -->
+    <string name="metric_type_none">Check only</string>
+    <string name="metric_type_strength">Weight &amp; reps</string>
+    <string name="metric_type_duration">Time</string>
+    <string name="metric_type_distance_duration">Distance &amp; time</string>
+    <string name="session_field_duration">Duration</string>
+    <string name="session_field_distance">Distance</string>
+    <string name="session_unit_min">min</string>
+    <string name="session_unit_km">km</string>
+    <string name="group_no_exercises">No exercises in %1$s yet.</string>
+    <string name="group_add_exercise">Add exercise</string>
+    <string name="group_exercise_name_placeholder">Deadlift</string>
+    <string name="add_metric_question">What do you want to log?</string>
+    <string name="add_new_category_option">New category…</string>
+    <string name="add_sheet_title">Add to your list</string>
+    <string name="add_done">Done</string>
+    <string name="add_in_your_list">In your list</string>
+    <string name="add_picker_all_added">Everything here is already in your list ✓ Try another category or create your own.</string>
+    <string name="add_picker_prompt_gym">Which muscle groups do you train?</string>
+    <string name="add_picker_prompt_generic">Which activities do you do?</string>
+    <string name="add_create_custom_title">New activity</string>
+    <string name="add_create_custom_title_gym">New group</string>
+    <string name="add_create_custom_gym">Create your own…</string>
+    <string name="add_create_custom_generic">Create your own…</string>
+    <string name="add_create_confirm">Add</string>
+    <string name="add_name_placeholder_gym">Glutes</string>
+    <string name="add_name_placeholder_generic">Climbing</string>
+    <string name="custom_category_default_metric">Default tracking</string>
+    <string name="empty_state_add_button">Add activity</string>
+    <plurals name="exercise_count">
+        <item quantity="one">%1$d exercise</item>
+        <item quantity="other">%1$d exercises</item>
+    </plurals>
+    <plurals name="history_month_summary_plural">
+        <item quantity="one">%1$d day trained in %2$s</item>
+        <item quantity="other">%1$d days trained in %2$s</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/xml/musclecheck_widget_info.xml
+++ b/android/app/src/main/res/xml/musclecheck_widget_info.xml
@@ -9,4 +9,5 @@
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="3600000"
     android:widgetCategory="home_screen"
+    android:previewLayout="@layout/widget_preview"
     android:description="@string/widget_description" />

--- a/android/app/src/test/java/com/zadkiel/musclecheck/domain/MetricAndExerciseTest.kt
+++ b/android/app/src/test/java/com/zadkiel/musclecheck/domain/MetricAndExerciseTest.kt
@@ -1,0 +1,186 @@
+package com.zadkiel.musclecheck.domain
+
+import com.zadkiel.musclecheck.domain.model.ActivityCategory
+import com.zadkiel.musclecheck.domain.model.CustomCategory
+import com.zadkiel.musclecheck.domain.model.Exercise
+import com.zadkiel.musclecheck.domain.model.MetricType
+import com.zadkiel.musclecheck.domain.model.MuscleEntry
+import com.zadkiel.musclecheck.domain.model.SessionFormatting
+import com.zadkiel.musclecheck.domain.model.WeightUnit
+import com.zadkiel.musclecheck.domain.model.WorkoutSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDate
+
+/** Ported from the iOS `ExerciseTests` / `MuscleEntryExerciseTests` semantics. */
+class MetricAndExerciseTest {
+
+    private val today = LocalDate.of(2026, 8, 12)
+
+    private fun session(
+        day: LocalDate,
+        weightKg: Double? = null,
+        durationSeconds: Int? = null,
+        distanceMeters: Double? = null,
+    ) = WorkoutSession(
+        id = "s-$day-$weightKg-$durationSeconds-$distanceMeters",
+        date = day,
+        weightKg = weightKg,
+        durationSeconds = durationSeconds,
+        distanceMeters = distanceMeters,
+    )
+
+    private fun entry(
+        category: String = ActivityCategory.GYM.id,
+        metricRaw: String = "",
+        sessions: List<WorkoutSession> = emptyList(),
+        exercises: List<Exercise> = emptyList(),
+    ) = MuscleEntry(
+        id = "e1",
+        name = "Legs",
+        isChecked = false,
+        weekOfYear = 33,
+        year = 2026,
+        dateCreated = Instant.EPOCH,
+        category = category,
+        icon = "figure.strengthtraining.traditional",
+        sessions = sessions,
+        metricRaw = metricRaw,
+        exercises = exercises,
+    )
+
+    // MARK: - Metric resolution
+
+    @Test
+    fun `empty metric falls back to the built-in category default`() {
+        assertEquals(MetricType.STRENGTH, entry(category = "gym").metric)
+        assertEquals(MetricType.DISTANCE_DURATION, entry(category = "running").metric)
+        assertEquals(MetricType.DURATION, entry(category = "yoga").metric)
+        assertEquals(MetricType.NONE, entry(category = "stretching").metric)
+    }
+
+    @Test
+    fun `explicit metric overrides the category default`() {
+        assertEquals(MetricType.DURATION, entry(category = "gym", metricRaw = "duration").metric)
+    }
+
+    @Test
+    fun `custom category default resolves through the resolver overload`() {
+        val custom = CustomCategory(
+            id = "cat-1", name = "Boxing", icon = "star.fill",
+            sortOrder = 9, tracksWeight = false, defaultMetricRaw = "duration",
+        )
+        assertEquals(MetricType.DURATION, entry(category = "cat-1").metricResolving(listOf(custom)))
+    }
+
+    @Test
+    fun `custom category without a metric migrates from tracksWeight`() {
+        val legacy = CustomCategory("c", "Legacy", "star.fill", 9, tracksWeight = true)
+        assertEquals(MetricType.STRENGTH, legacy.defaultMetric)
+        val legacyNoWeight = legacy.copy(tracksWeight = false)
+        assertEquals(MetricType.NONE, legacyNoWeight.defaultMetric)
+    }
+
+    // MARK: - Formatting
+
+    @Test
+    fun `label formats each metric and returns null when nothing is recorded`() {
+        assertNull(SessionFormatting.label(MetricType.NONE, weightKg = 100.0))
+        assertEquals("100 kg", SessionFormatting.label(MetricType.STRENGTH, weightKg = 100.0))
+        assertEquals("45 min", SessionFormatting.label(MetricType.DURATION, durationSeconds = 2700))
+        assertEquals(
+            "5.2 km · 32 min",
+            SessionFormatting.label(
+                MetricType.DISTANCE_DURATION,
+                durationSeconds = 1920,
+                distanceMeters = 5200.0,
+            ),
+        )
+        assertNull(SessionFormatting.label(MetricType.STRENGTH, weightKg = null))
+    }
+
+    @Test
+    fun `distanceDuration keeps the single value it has`() {
+        assertEquals(
+            "5.0 km",
+            SessionFormatting.label(MetricType.DISTANCE_DURATION, distanceMeters = 5000.0),
+        )
+    }
+
+    @Test
+    fun `weight is converted to the display unit`() {
+        assertEquals("220 lbs", SessionFormatting.formatWeight(100.0, WeightUnit.LBS))
+    }
+
+    // MARK: - Exercise
+
+    @Test
+    fun `last values come from the most recent session that has them`() {
+        val exercise = Exercise(
+            id = "x", name = "Deadlift", icon = "i", metricRaw = "strength",
+            sessions = listOf(
+                session(today.minusDays(5), weightKg = 80.0),
+                session(today.minusDays(1), weightKg = 100.0),
+                session(today), // no values: must not erase the last known weight
+            ),
+        )
+        assertEquals(100.0, exercise.lastWeightKg!!, 0.001)
+        assertEquals("100 kg", exercise.summary(WeightUnit.KG))
+    }
+
+    @Test
+    fun `distance and duration are read from the same session`() {
+        val exercise = Exercise(
+            id = "x", name = "Run", icon = "i", metricRaw = "distanceDuration",
+            sessions = listOf(
+                session(today.minusDays(3), distanceMeters = 10000.0),
+                session(today, durationSeconds = 1800, distanceMeters = 5000.0),
+            ),
+        )
+        // Not "10.0 km · 30 min": both values belong to today's session.
+        assertEquals("5.0 km · 30 min", exercise.summary(WeightUnit.KG))
+    }
+
+    // MARK: - Group summary
+
+    @Test
+    fun `group with no exercises falls back to its own value`() {
+        val group = entry(metricRaw = "strength", sessions = listOf(session(today, weightKg = 60.0)))
+        val summary = group.summary(WeightUnit.KG)!!
+        assertEquals(0, summary.exerciseCount)
+        assertEquals("60 kg", summary.ownLabel)
+    }
+
+    @Test
+    fun `group with exercises reports the count and the most recent one`() {
+        val group = entry(
+            metricRaw = "strength",
+            exercises = listOf(
+                Exercise("a", "Squat", "i", "strength", listOf(session(today.minusDays(2), weightKg = 90.0))),
+                Exercise("b", "Deadlift", "i", "strength", listOf(session(today, weightKg = 120.0))),
+            ),
+        )
+        val summary = group.summary(WeightUnit.KG)!!
+        assertEquals(2, summary.exerciseCount)
+        assertEquals("Deadlift", summary.recentName)
+        assertEquals("120 kg", summary.recentValue)
+    }
+
+    @Test
+    fun `group with exercises that were never logged reports only the count`() {
+        val group = entry(
+            metricRaw = "strength",
+            exercises = listOf(Exercise("a", "Squat", "i", "strength", emptyList())),
+        )
+        val summary = group.summary(WeightUnit.KG)!!
+        assertEquals(1, summary.exerciseCount)
+        assertNull(summary.recentValue)
+    }
+
+    @Test
+    fun `group with nothing logged has no summary`() {
+        assertNull(entry(metricRaw = "strength").summary(WeightUnit.KG))
+    }
+}


### PR DESCRIPTION
Lleva Android de 2.1.x a paridad funcional con iOS 2.2.0, portando las Features 18 y 19.

## Métrica por ejercicio (Feature 18)
- `MetricType` (none/strength/duration/distanceDuration) + `SessionFormatting` como formateador único, compartido por home e historial.
- `WorkoutSession` gana `durationSeconds` y `distanceMeters`. La categoría solo aporta el default (gym→peso, running→distancia+tiempo, cardio/yoga/pilates→tiempo) y cada entrada puede pisarlo.
- Migración aditiva: `metricRaw == ""` se resuelve lazy desde la categoría y lo persiste un backfill idempotente al arranque, mismo patrón que iOS.
- Regla de duplicados unificada y case-insensitive.

## Ejercicios dentro del grupo (Feature 19)
- `Exercise` con historial propio, en tablas relacionales (`exercises` / `exercise_sessions`) en vez del array Codable inline de iOS: Room es relacional y ya había precedente con `workout_sessions`.
- Guardar un ejercicio marca el grupo entrenado ese día, así racha, stats, notificaciones y widget siguen leyendo las sesiones del grupo **sin tocarse**.
- `GroupDetailSheet` nuevo; `SessionLogSheet` desacoplado vía `SessionLogTarget`.

## Alta unificada y discoverability
- El sheet de alta pasa a ser un picker: chips de categoría, presets de un tap con estado "en tu lista", nombre libre y categoría nueva inline.
- El "+" sale del toolbar y pasa a un FAB. Con tres íconos el título deja de envolver a dos líneas.
- Empty state con CTA real — era el feedback original de discoverability.

## Correcciones de paso
- Plurals reales: "1 día entrenado", no "1 days trained".
- `imePadding` en los sheets; el teclado tapaba el botón de guardar.
- Se quita la fila "AI coach" del paywall: no existe en Android.
- Preview del widget, kg/lbs en la paleta de la app, versionName 2.2.0.

## Verificación
- Room v3 con `fallbackToDestructiveMigration` (sin usuarios en Play todavía).
- 38 tests JVM verdes, 13 nuevos portando la semántica de `ExerciseTests`.
- Recorrido completo en emulador: onboarding, alta, ejercicios, historial, widget refrescándose ante la mutación.

## Fuera de alcance
AI Coach, HealthKit y App Intents quedan iOS-only por imposibilidad técnica, no por recorte: FoundationModels es on-device de Apple y no tiene equivalente portable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)