### PR TITLE
chore(android): firma de release, R8 y protección del upload key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,8 @@ MuscleCheck/GoogleService-Info.plist
 /GoogleService-Info.plist
 */GoogleService-Info.plist
 .build-dd/
+
+# Android release signing — never commit the upload key or its passwords
+android/keystore.properties
+*.jks
+*.keystore

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -5,6 +7,17 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
+
+// Release signing credentials live in keystore.properties, which is gitignored — the
+// upload key must never reach the repo. Absent (CI, a fresh clone), the release build
+// still runs and just comes out unsigned, so `bundleRelease` stays verifiable.
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = Properties().apply {
+    if (keystorePropertiesFile.exists()) {
+        keystorePropertiesFile.inputStream().use { load(it) }
+    }
+}
+val hasReleaseSigning = keystoreProperties.getProperty("storeFile") != null
 
 android {
     namespace = "com.zadkiel.musclecheck"
@@ -20,13 +33,31 @@ android {
         versionName = "2.2.0"
     }
 
+    signingConfigs {
+        if (hasReleaseSigning) {
+            create("release") {
+                storeFile = rootProject.file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            isMinifyEnabled = false
+            // R8 on: smaller download and the config Play actually serves. Keep it
+            // enabled locally too, so a rule missing for Room/Hilt/Glance surfaces
+            // here and not in a crash report from the store.
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
     compileOptions {

--- a/android/keystore.properties.example
+++ b/android/keystore.properties.example
@@ -1,0 +1,12 @@
+# Copy to keystore.properties (gitignored) and fill in with the values you chose when
+# running keytool. storeFile is relative to the `android/` directory.
+#
+#   keytool -genkey -v -keystore musclecheck-release.jks -keyalg RSA \
+#     -keysize 2048 -validity 10000 -alias musclecheck
+#
+# Back the .jks up somewhere durable: lose it and this app can never be updated again
+# under the same package name (unless Play Signing is enabled and you request a reset).
+storeFile=musclecheck-release.jks
+storePassword=
+keyAlias=musclecheck
+keyPassword=


### PR DESCRIPTION
Apilado sobre #32. Deja el build listo para subir a Play.

- `signingConfig` de release leyendo `android/keystore.properties`, gitignoreado junto con `*.jks`. Si el archivo no existe el build igual corre y el bundle sale sin firmar, así CI y un clone limpio no se rompen.
- **R8 y `shrinkResources` activados.** Estaban apagados, lo que significaba subir a la tienda una configuración nunca ejecutada. Verificado en emulador que Room, Hilt y Glance sobreviven a la minificación, y sin reglas faltantes.
- `keystore.properties.example` documentando el formato y el comando de `keytool`.

AAB resultante: 5,3 MB, `jarsigner -verify` OK.

> El upload key y sus contraseñas no están en el repo y no deben estarlo. El `.jks` hay que respaldarlo fuera de la máquina: perderlo impide actualizar la app bajo el mismo package name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)